### PR TITLE
Add missing include

### DIFF
--- a/src/Utils.C
+++ b/src/Utils.C
@@ -1,3 +1,4 @@
+#include <cmath>
 #include "Utils.h"
 
 Utils::Utils(bool DRAWLOGO) {


### PR DESCRIPTION
This PR fixes the following compile error with modern Clang on Mac:

```
src/Utils.C:363:16: error: expected unqualified-id
      if (std::isnan(val) || std::isinf(val)) {
               ^
/usr/include/math.h:179:5: note: expanded from macro 'isnan'
    ( sizeof(x) == sizeof(float)  ? __inline_isnanf((float)(x))          \
    ^
```

http://en.cppreference.com/w/cpp/numeric/math/isnan
