### PR TITLE
Fix setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docu/doxygen/xml/
 docu/sphinx/build/
 python/_gamerapy.cc
 python/build/
+_gappa.cc

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,24 +1,29 @@
 from distutils.core import setup, Extension
-import string
+import os
 import sys
-import subprocess
-GSL_LIBS = subprocess.check_output(['gsl-config','--libs']).split()
-GSL_CFLAGS = subprocess.check_output(['gsl-config','--cflags']).split()
 
-if(GSL_CFLAGS):
-  COMPILEARGS=GSL_CFLAGS
-  COMPILEARGS.append('-std=c++11')
-else:
-  COMPILEARGS=['-std=c++11']
+# Use the bundeled pkgconfig
+here = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, here)
+import pkgconfig
+
+extra_link_args = pkgconfig.libs('gsl').split()
+
+extra_compile_args = pkgconfig.cflags('gsl').split()
+extra_compile_args.append('-std=c++11')
 
 if sys.platform == 'darwin':
-  COMPILEARGS.append('-w')
+    extra_compile_args.append('-w')
 
-extension_mod = Extension("_gappa",
-                          ["_gappa.cc", "../src/Radiation.C","../src/Particles.C","../src/Utils.C","../src/Astro.C"],
-                          extra_compile_args=COMPILEARGS,
-                          extra_link_args=GSL_LIBS,
-                          include_dirs=['../include'],
+extension_mod = Extension(
+    "_gappa",
+    ["_gappa.cc", "../src/Radiation.C", "../src/Particles.C", "../src/Utils.C", "../src/Astro.C"],
+    extra_compile_args=extra_compile_args,
+    extra_link_args=extra_link_args,
+    include_dirs=['../include'],
 )
 
-setup(name = "gappa", ext_modules=[extension_mod])
+setup(
+    name="gappa",
+    ext_modules=[extension_mod],
+)


### PR DESCRIPTION
This PR fixes setup.py.
The previous version didn't work on Python 3, because `subprocess.check_output` returns a `bytes` object.
This version should work on Python 2 and 3.
