### PR TITLE
Removal of -std=c++11 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GSLCFLAGS := $(shell gsl-config --cflags)
 GSLLIBS := $(shell gsl-config --libs)
 
 # define additional switches to be passed to the compiler
-CXXFLAGS := $(GSLCFLAGS) -std=c++11 -m64
+CXXFLAGS := $(GSLCFLAGS) -m64
 
 # define additional switches to be passed to the linker
 LDFLAGS := $(GSLLIBS)

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -30,13 +30,13 @@ using namespace std;
 template <typename F>
 class GSLfuncPart : public gsl_function {
  public:
-  GSLfuncPart(const F &func) : _func(func) {
+  GSLfuncPart(const F func) : _func(func) {
     function = &GSLfuncPart::Call;
     params = this;
   }
  ~GSLfuncPart() {}
  private:
-  const F &_func;
+  const F _func;
   static double Call(double x, void *params) {
     return static_cast<GSLfuncPart *>(params)->_func(x);
   }
@@ -44,6 +44,16 @@ class GSLfuncPart : public gsl_function {
 
 class Particles {
   typedef double (Particles::*fPointer)(double, void *);
+
+  static void initialise(fPointer funcPtr, Particles *partPtr) {
+    _funcPtr = funcPtr;
+    _partPtr = partPtr;
+  }
+  static double evaluate(double x, void* params) {
+    return (_partPtr->*_funcPtr)(x, params);
+  }
+  static fPointer _funcPtr;
+  static Particles *_partPtr;
 
 struct timespec time0, time1, time2, time3;
  private:

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -27,21 +27,6 @@ using namespace std;
  */
 
 
-template <typename F>
-class GSLfuncPart : public gsl_function {
- public:
-  GSLfuncPart(const F func) : _func(func) {
-    function = &GSLfuncPart::Call;
-    params = this;
-  }
- ~GSLfuncPart() {}
- private:
-  const F _func;
-  static double Call(double x, void *params) {
-    return static_cast<GSLfuncPart *>(params)->_func(x);
-  }
-};
-
 class Particles {
   typedef double (Particles::*fPointer)(double, void *);
 

--- a/include/Radiation.h
+++ b/include/Radiation.h
@@ -12,21 +12,6 @@ using namespace std;
 
 typedef double (*fGSLPointer)(double, void *);
 
-template <typename F>
-class GSLfuncRad : public gsl_function {
- public:
-  GSLfuncRad(const F &func) : _func(func) {
-    function = &GSLfuncRad::Call;
-    params = this;
-  }
-
- private:
-  const F &_func;
-  static double Call(double x, void *params) {
-    return static_cast<GSLfuncRad *>(params)->_func(x);
-  }
-};
-
 /**  @file Radiation.C
  *   @author Joachim Hahn
  *   @short Class that calculates broad band emission from particle spectra.

--- a/include/Radiation.h
+++ b/include/Radiation.h
@@ -35,6 +35,16 @@ class GSLfuncRad : public gsl_function {
 class Radiation {
   typedef double (Radiation::*fPointer)(double, void *);
 
+  static void initialise(fPointer funcPtr, Radiation *radPtr) {
+    _funcPtr = funcPtr;
+    _radPtr = radPtr;
+  }
+  static double evaluate(double x, void* params) {
+    return (_radPtr->*_funcPtr)(x, params);
+  }
+  static fPointer _funcPtr;
+  static Radiation *_radPtr;
+
  private:
   void CalculateLuminosityAndFlux(string mechanism, double e, double &l,
                                   double &f);

--- a/src/Astro.C
+++ b/src/Astro.C
@@ -2010,20 +2010,20 @@ void Astro::CalculateTrueLoveMcKeeParams(vector<double> pars) {
   double charvelocitytruelovemckee=charradiustruelovemckee/chartimetruelovemckee;
 
   /* format: {l_ED,w_core,phi_ED,phi_EDeff,t*_ST,R*_ST,R*_r_ST,v~*_r_ST,a~*_r_ST,t*_ref,t*_core,r*_r_core,v~*_r_core,a~*_r_core,f_n,alpha,eta} */
-  if(!index)          truelovemckeeparams = {  1.1,  0., 0.343, 0.0961, 0.495, 0.727, 0.545, 0.585, 0.106,  0.,    0.,    0.,    0.,    0.};
-  else if(index== 2.) truelovemckeeparams = {  1.1,  0., 0.343, 0.0947, 0.387, 0.679, 0.503, 0.686,-0.151, 1.6,    0.,    0.,    0.,    0.};
-  else if(index== 4.) truelovemckeeparams = {  1.1, 0.1, 0.343, 0.0791, 0.232, 0.587,    0.,    0.,    0.,  0.,   1.7,    0.,    0.,    0.};
-  else if(index== 6.) truelovemckeeparams = { 1.39,  0.,  0.39,     0.,  1.04,  1.07,    0.,    0.,    0.,  0., 0.513, 0.541, 0.527, 0.112};
-  else if(index== 7.) truelovemckeeparams = { 1.26,  0.,  0.47,     0., 0.732, 0.881,    0.,    0.,    0.,  0., 0.363, 0.469, 0.553, 0.116};
-  else if(index== 8.) truelovemckeeparams = { 1.21,  0.,  0.52,     0., 0.605, 0.788,    0.,    0.,    0.,  0., 0.292, 0.413, 0.530, 0.139};
-  else if(index== 9.) truelovemckeeparams = { 1.19,  0.,  0.55,     0., 0.523, 0.725,    0.,    0.,    0.,  0., 0.249, 0.371, 0.497, 0.162};
-  else if(index==10.) truelovemckeeparams = { 1.17,  0.,  0.57,     0., 0.481, 0.687,    0.,    0.,    0.,  0., 0.220, 0.340, 0.463, 0.192};
-  else if(index==12.) truelovemckeeparams = { 1.15,  0.,  0.60,     0., 0.424, 0.636,    0.,    0.,    0.,  0., 0.182, 0.293, 0.403, 0.251};
-  else if(index==14.) truelovemckeeparams = { 1.14,  0.,  0.62,     0., 0.389, 0.603,    0.,    0.,    0.,  0., 0.157, 0.259, 0.354, 0.277};
+  if(!index)          { static const double itl[] = {  1.1,  0., 0.343, 0.0961, 0.495, 0.727, 0.545, 0.585, 0.106,  0.,    0.,    0.,    0.,    0.}; truelovemckeeparams = vector<double>(itl, itl + sizeof(itl)/sizeof(double)); }
+  else if(index== 2.) { static const double itl[] = {  1.1,  0., 0.343, 0.0947, 0.387, 0.679, 0.503, 0.686,-0.151, 1.6,    0.,    0.,    0.,    0.}; truelovemckeeparams = vector<double>(itl, itl + sizeof(itl)/sizeof(double)); }
+  else if(index== 4.) { static const double itl[] = {  1.1, 0.1, 0.343, 0.0791, 0.232, 0.587,    0.,    0.,    0.,  0.,   1.7,    0.,    0.,    0.}; truelovemckeeparams = vector<double>(itl, itl + sizeof(itl)/sizeof(double)); }
+  else if(index== 6.) { static const double itl[] = { 1.39,  0.,  0.39,     0.,  1.04,  1.07,    0.,    0.,    0.,  0., 0.513, 0.541, 0.527, 0.112}; truelovemckeeparams = vector<double>(itl, itl + sizeof(itl)/sizeof(double)); }
+  else if(index== 7.) { static const double itl[] = { 1.26,  0.,  0.47,     0., 0.732, 0.881,    0.,    0.,    0.,  0., 0.363, 0.469, 0.553, 0.116}; truelovemckeeparams = vector<double>(itl, itl + sizeof(itl)/sizeof(double)); }
+  else if(index== 8.) { static const double itl[] = { 1.21,  0.,  0.52,     0., 0.605, 0.788,    0.,    0.,    0.,  0., 0.292, 0.413, 0.530, 0.139}; truelovemckeeparams = vector<double>(itl, itl + sizeof(itl)/sizeof(double)); }
+  else if(index== 9.) { static const double itl[] = { 1.19,  0.,  0.55,     0., 0.523, 0.725,    0.,    0.,    0.,  0., 0.249, 0.371, 0.497, 0.162}; truelovemckeeparams = vector<double>(itl, itl + sizeof(itl)/sizeof(double)); }
+  else if(index==10.) { static const double itl[] = { 1.17,  0.,  0.57,     0., 0.481, 0.687,    0.,    0.,    0.,  0., 0.220, 0.340, 0.463, 0.192}; truelovemckeeparams = vector<double>(itl, itl + sizeof(itl)/sizeof(double)); }
+  else if(index==12.) { static const double itl[] = { 1.15,  0.,  0.60,     0., 0.424, 0.636,    0.,    0.,    0.,  0., 0.182, 0.293, 0.403, 0.251}; truelovemckeeparams = vector<double>(itl, itl + sizeof(itl)/sizeof(double)); }
+  else if(index==14.) { static const double itl[] = { 1.14,  0.,  0.62,     0., 0.389, 0.603,    0.,    0.,    0.,  0., 0.157, 0.259, 0.354, 0.277}; truelovemckeeparams = vector<double>(itl, itl + sizeof(itl)/sizeof(double)); }
   else {
     cout << "Astro::CalculateTrueLoveMcKeeParams: Density Index (index="
          << index << ") not supported! Returning nothing." << endl;
-    truelovemckeeparams={};
+    truelovemckeeparams= vector<double>();
     return;
   }
 
@@ -2054,13 +2054,14 @@ void Astro::CalculateTrueLoveMcKeeParams(vector<double> pars) {
     return;
   }
   if(!QUIETMODE) {
-    vector<string> ParNames = {"l_ED","w_core","phi_ED","phi_EDeff","t*_ST",
+    string ParNamesArr[] = {"l_ED","w_core","phi_ED","phi_EDeff","t*_ST",
                                "R*_ST","R*_r_ST","v~*_r_ST","a~*_r_ST","t*_ref",
                                "t*_core","r*_r_core","v~*_r_core","a~*_r_core",
                                "f_n","alpha","eta","charradiustruelovemckee",
                                "chartimetruelovemckee",
                                "charvelocitytruelovemckee","sedovtaylortime",
                                "coreexittime","index"};
+    vector<string> ParNames( ParNamesArr, ParNamesArr + ( sizeof ( ParNamesArr ) /  sizeof ( std::string ) ) );
     cout << ">> Paramaters for Truelove & McKee's solution (density index = "
          << index << "):" <<std::endl;
     for(unsigned int i=0;i<truelovemckeeparams.size();i++) {

--- a/src/Particles.C
+++ b/src/Particles.C
@@ -443,14 +443,20 @@ void Particles::SetLookup(vector<vector<double> > v, string LookupType) {
 //    std::cout<< " ... ... ... "<<std::endl;
 //  }
   gsl_spline *ImportLookup = fUtils->GSLsplineFromTwoDVector(lookup);
-  vector<string> st{"ICLoss", "Luminosity", "AmbientDensity", "BField",
+  std::string stArr[] = {"ICLoss", "Luminosity", "AmbientDensity", "BField",
                     "Emax", "Radius",         "Speed"};
-  vector<gsl_spline **> spl{&ICLossLookup, &LumLookup,  &NLookup,
+  // unsigned int st_size = 7;
+  vector<string> st( stArr, stArr + ( sizeof ( stArr ) /  sizeof ( stArr[0] ) ) );
+  gsl_spline **splArr[] = {&ICLossLookup, &LumLookup,  &NLookup,
                             &BFieldLookup, &eMaxLookup,
                             &RLookup,      &VLookup};
-  vector<vector<vector<double> > *> vs{
+  vector<gsl_spline **> spl( splArr, splArr + ( sizeof ( splArr ) /  sizeof ( splArr[0] ) ) );
+  // vector<gsl_spline **> spl(gsl_spliner, gsl_spliner + (sizeof (gsl_spliner) / sizeof(gsl_spline **)));
+
+  vector<vector<double> > * vsArr[] = {
       &ICLossVector, &LumVector,        &NVector, &BVector,
       &eMaxVector, &RVector, &VVector};
+  vector<vector<vector<double> > *> vs( vsArr, vsArr + ( sizeof ( vsArr ) /  sizeof ( vsArr[0] ) ) );
   
   for (unsigned int i = 0; i < st.size(); i++) {
     if (!LookupType.compare(st[i])) {
@@ -482,9 +488,10 @@ void Particles::ExtendLookup(vector<vector<double> > v, string LookupType) {
     cout << "Particles::ExtendLookup: Input vector empty. Exiting." << endl;
     return;
   }
-  vector<string> st = {"Luminosity", "AmbientDensity", "BField", "Emax",
+  string st[] = {"Luminosity", "AmbientDensity", "BField", "Emax",
                        "Radius",         "Speed"};
-  vector<vector<vector<double> > > vs = {LumVector,  NVector,          BVector,
+  unsigned int st_size = 6;
+  vector<vector<double> > vs[] = {LumVector,  NVector,          BVector,
                                          eMaxVector, RVector,  VVector};
   vector< vector< double > > lookup;
   if (!LookupType.compare("Luminosity") || !LookupType.compare("Emax")) {
@@ -493,7 +500,7 @@ void Particles::ExtendLookup(vector<vector<double> > v, string LookupType) {
   else {
     lookup = v;
   }
-  for (unsigned int i = 0; i < st.size(); i++) {
+  for (unsigned int i = 0; i < st_size; i++) {
     if (!LookupType.compare(st[i])) {
       if (vs[i][vs[i].size() - 1][0] > lookup[0][0]) {
         cout << "Particles::ExtendCRLumLookup - WTF, the vector which to add ("
@@ -1366,21 +1373,10 @@ double Particles::Integrate(fPointer f, double *x, double emin, double emax,
                             double tolerance, int kronrodrule) {
   double integral, error;
   /* no comment */
-  // auto ptr = [=](double xx)->double {
-  //   return (this->*f)(xx, (void *)x);
-  // };
-
-  // GSLfuncPart<decltype(ptr)> Fp(ptr);
-  // gsl_function F = *static_cast<gsl_function *>(&Fp);
-
   gsl_function F;
   initialise(f, this);
   F.function = &evaluate;
   F.params = x;
-
-
-
-  // gsl_function F = *static_cast<gsl_function *>(&Fp);
   
   gsl_integration_workspace *w = gsl_integration_workspace_alloc(gslmemory);
   if (gsl_integration_qag(&F, emin, emax, 0, tolerance, gslmemory, kronrodrule,

--- a/src/Particles.C
+++ b/src/Particles.C
@@ -488,11 +488,12 @@ void Particles::ExtendLookup(vector<vector<double> > v, string LookupType) {
     cout << "Particles::ExtendLookup: Input vector empty. Exiting." << endl;
     return;
   }
-  string st[] = {"Luminosity", "AmbientDensity", "BField", "Emax",
+  string stArr[] = {"Luminosity", "AmbientDensity", "BField", "Emax",
                        "Radius",         "Speed"};
-  unsigned int st_size = 6;
-  vector<vector<double> > vs[] = {LumVector,  NVector,          BVector,
+  vector<string> st( stArr, stArr + ( sizeof ( stArr ) /  sizeof ( stArr[0] ) ) );
+  vector<vector<double> > vsArr[] = {LumVector,  NVector,          BVector,
                                          eMaxVector, RVector,  VVector};
+  vector<vector<vector<double> > > vs( vsArr, vsArr + ( sizeof ( vsArr ) /  sizeof ( vsArr[0] ) ) );
   vector< vector< double > > lookup;
   if (!LookupType.compare("Luminosity") || !LookupType.compare("Emax")) {
     lookup = fUtils->VectorAxisLogarithm(v,1);
@@ -500,7 +501,7 @@ void Particles::ExtendLookup(vector<vector<double> > v, string LookupType) {
   else {
     lookup = v;
   }
-  for (unsigned int i = 0; i < st_size; i++) {
+  for (unsigned int i = 0; i < st.size(); i++) {
     if (!LookupType.compare(st[i])) {
       if (vs[i][vs[i].size() - 1][0] > lookup[0][0]) {
         cout << "Particles::ExtendCRLumLookup - WTF, the vector which to add ("

--- a/src/Particles.C
+++ b/src/Particles.C
@@ -1359,15 +1359,29 @@ void Particles::SetIntegratorMemory(string mode) {
  * Integration function using the GSL QAG functionality
  *
  */
+Particles::fPointer Particles::_funcPtr;
+Particles *Particles::_partPtr;
+
 double Particles::Integrate(fPointer f, double *x, double emin, double emax,
                             double tolerance, int kronrodrule) {
   double integral, error;
   /* no comment */
-  auto ptr = [=](double xx)->double {
-    return (this->*f)(xx, (void *)x);
-  };
-  GSLfuncPart<decltype(ptr)> Fp(ptr);
-  gsl_function F = *static_cast<gsl_function *>(&Fp);
+  // auto ptr = [=](double xx)->double {
+  //   return (this->*f)(xx, (void *)x);
+  // };
+
+  // GSLfuncPart<decltype(ptr)> Fp(ptr);
+  // gsl_function F = *static_cast<gsl_function *>(&Fp);
+
+  gsl_function F;
+  initialise(f, this);
+  F.function = &evaluate;
+  F.params = x;
+
+
+
+  // gsl_function F = *static_cast<gsl_function *>(&Fp);
+  
   gsl_integration_workspace *w = gsl_integration_workspace_alloc(gslmemory);
   if (gsl_integration_qag(&F, emin, emax, 0, tolerance, gslmemory, kronrodrule,
                           w, &integral,&error)) {

--- a/src/Particles.C
+++ b/src/Particles.C
@@ -445,13 +445,11 @@ void Particles::SetLookup(vector<vector<double> > v, string LookupType) {
   gsl_spline *ImportLookup = fUtils->GSLsplineFromTwoDVector(lookup);
   std::string stArr[] = {"ICLoss", "Luminosity", "AmbientDensity", "BField",
                     "Emax", "Radius",         "Speed"};
-  // unsigned int st_size = 7;
   vector<string> st( stArr, stArr + ( sizeof ( stArr ) /  sizeof ( stArr[0] ) ) );
   gsl_spline **splArr[] = {&ICLossLookup, &LumLookup,  &NLookup,
                             &BFieldLookup, &eMaxLookup,
                             &RLookup,      &VLookup};
   vector<gsl_spline **> spl( splArr, splArr + ( sizeof ( splArr ) /  sizeof ( splArr[0] ) ) );
-  // vector<gsl_spline **> spl(gsl_spliner, gsl_spliner + (sizeof (gsl_spliner) / sizeof(gsl_spline **)));
 
   vector<vector<double> > * vsArr[] = {
       &ICLossVector, &LumVector,        &NVector, &BVector,

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -1593,15 +1593,19 @@ vector<vector<double> > Radiation::GetParticleSED(string type) {
  * Integration function using the GSL QAG functionality
  *
  */
+Radiation::fPointer Radiation::_funcPtr;
+Radiation *Radiation::_radPtr;
+
 double Radiation::Integrate(fPointer f, double *x, double emin, double emax,
                             double tolerance, int kronrodrule) {
   double integral, error;
-  auto ptr = [=](double xx)->double {
-    return (this->*f)(xx, (void *)x);
-  };
+  
+  gsl_function F;
+  initialise(f, this);
+  F.function = &evaluate;
+  F.params = x;
+
   gsl_integration_workspace *w = gsl_integration_workspace_alloc(10000);
-  GSLfuncRad<decltype(ptr)> Fp(ptr);
-  gsl_function F = *static_cast<gsl_function *>(&Fp);
   if (gsl_integration_qag(&F, emin, emax, 0, tolerance, 10000, kronrodrule, w,
                           &integral, &error))
     return 0.;


### PR DESCRIPTION
Crudely removed the need for the c++11 compiler flag.
Used a static function for the gsl_function struct and replaced the std::vector initializer lists.