### PR TITLE
Anisotropic IC for isotropic electrons

### DIFF
--- a/include/Particles.h
+++ b/include/Particles.h
@@ -254,6 +254,8 @@ struct timespec time0, time1, time2, time3;
   double GetMinModSlope(int i, double deltaX,int i0);  ///< slope for the
                                                          ///minmod slope limiter
                                                          ///method
+  double LaxWendroffSlope(int i, double deltaX, int i0);  ///< slope for the
+                                                          // Lax-Wendroff slope limiter
   vector<vector<double> > ParticleSpectrum;  ///< vector containing the final
                                              ///source particle spectrum (i.e.
                                              ///at time=Age)

--- a/include/Radiation.h
+++ b/include/Radiation.h
@@ -36,6 +36,7 @@ class Radiation {
   bool FASTMODE_IC; ///< speed up IC calculation by not calculating emission on
                    /// isotropic target fields individually but only sum
   bool IC_CALCULATED;
+  bool ISOTROPIC_ELECTRONS; /// < Set to true for isotropic electrons in IC scattering
   bool FASTMODE_IC_LOSSLOOK; ///< speed up IC calculation by not calculating emission on
                    /// isotropic target fields individually but only sum
   bool IC_LOSSLOOK_CALCULATED;
@@ -47,7 +48,9 @@ class Radiation {
   double ICAnisotropicAuxFunc(double phi_p, double theta_p, double ephoton,
                               double egamma, double lorentz, double beta, 
                               double cos_zeta);
-
+  double ICEmissivityAnisotropicIsotropicElectrons(double x, void *par);
+  double ICEmissivityAnisotropicSecondIntegral(double x, void *par);
+  double ICEmissivityAnisotropicFirstIntegral(double x, void *par);
   double K(double nu, double x);             ///< modified Bessel function
   double K_53(double x, void *par);  ///< modified Bessel function of order 5/3
   double SynchEmissivity(double x, void *par);  ///< Synchrotron emission from a
@@ -260,6 +263,8 @@ class Radiation {
                                                          ///spectra). Input
                                                          ///format: 2D vector,
                                                          ///E(erg)-N(number)
+  void SetElectronsIsotropic(void);			///<Setting isotropic electrons variable
+						/// to true for anisotropic IC scattering
   vector<vector<double> > GetProtonVector() {
     return ProtonVector;
   }  ///< return proton spectrum return format: 2D vector

--- a/include/Radiation.h
+++ b/include/Radiation.h
@@ -37,6 +37,8 @@ class Radiation {
                    /// isotropic target fields individually but only sum
   bool IC_CALCULATED;
   bool ISOTROPIC_ELECTRONS; /// < Set to true for isotropic electrons in IC scattering
+  bool USE_AHARONIAN; // < Set to true if Aharonians equation for isotropic el. in ansiotropic
+			// IC scattering is used
   bool FASTMODE_IC_LOSSLOOK; ///< speed up IC calculation by not calculating emission on
                    /// isotropic target fields individually but only sum
   bool IC_LOSSLOOK_CALCULATED;
@@ -51,6 +53,10 @@ class Radiation {
   double ICEmissivityAnisotropicIsotropicElectrons(double x, void *par);
   double ICEmissivityAnisotropicSecondIntegral(double x, void *par);
   double ICEmissivityAnisotropicFirstIntegral(double x, void *par);
+  double ICEmissivityAnisotropicIsotropicElectronsAharonian(double x, void *par);
+  double ICEmissivityAnisotropicIsotropicElectronsAharonianSecondIntegral(double x, void *par);
+  double ICEmissivityAnisotropicIsotropicElectronsAharonianFirstIntegral(double x, void *par);
+  void UseAharonian(void);
   double K(double nu, double x);             ///< modified Bessel function
   double K_53(double x, void *par);  ///< modified Bessel function of order 5/3
   double SynchEmissivity(double x, void *par);  ///< Synchrotron emission from a

--- a/include/Radiation.h
+++ b/include/Radiation.h
@@ -37,8 +37,7 @@ class Radiation {
                    /// isotropic target fields individually but only sum
   bool IC_CALCULATED;
   bool ISOTROPIC_ELECTRONS; /// < Set to true for isotropic electrons in IC scattering
-  bool USE_AHARONIAN; // < Set to true if Aharonians equation for isotropic el. in ansiotropic
-			// IC scattering is used
+
   bool FASTMODE_IC_LOSSLOOK; ///< speed up IC calculation by not calculating emission on
                    /// isotropic target fields individually but only sum
   bool IC_LOSSLOOK_CALCULATED;
@@ -51,12 +50,13 @@ class Radiation {
                               double egamma, double lorentz, double beta, 
                               double cos_zeta);
   double ICEmissivityAnisotropicIsotropicElectrons(double x, void *par);
+  double ICEmissivityAnisotropicIsotropicElectronsSecondIntegral(double x, void *par);
+  double ICEmissivityAnisotropicIsotropicElectronsFirstIntegral(double x, void *par);
   double ICEmissivityAnisotropicSecondIntegral(double x, void *par);
   double ICEmissivityAnisotropicFirstIntegral(double x, void *par);
   double ICEmissivityAnisotropicIsotropicElectronsAharonian(double x, void *par);
   double ICEmissivityAnisotropicIsotropicElectronsAharonianSecondIntegral(double x, void *par);
   double ICEmissivityAnisotropicIsotropicElectronsAharonianFirstIntegral(double x, void *par);
-  void UseAharonian(void);
   double K(double nu, double x);             ///< modified Bessel function
   double K_53(double x, void *par);  ///< modified Bessel function of order 5/3
   double SynchEmissivity(double x, void *par);  ///< Synchrotron emission from a

--- a/src/Particles.C
+++ b/src/Particles.C
@@ -889,21 +889,26 @@ void Particles::ComputeGrid(vector<double> EnergyAxis, double startTime,
       /* slope limiters (per default enabled, toggle on/off with FASTMODE flag) */    
       if(FASTMODE == false) {
         double mm,sb;
-        // uncomment the following def. for Lax-Wendroff slope limiter
+        /* Uncomment the following lines if you want to use the
+         * Lax-Wendroff slope limiter. You also have to comment
+         * the code after until the curly bracket. Normally you
+         * don't want to do this, the MinMod slope limiter is better */
         /*mm =  quot * (LaxWendroffSlope(i, ebin, i0) * ElossRate_e1 *
                 (ebin - deltaE1) -
                              LaxWendroffSlope(i + 1, ebin, i0) * ElossRate_e2 *
-                                 (ebin - deltaE2));*/
-        //Comment this line if Lax-Wendroff is used
+                                 (ebin - deltaE2));
+        double lw = 0.5*quot*(LaxWendroffSlope(i,ebin,i0)*ElossRate_e1*(ebin-deltaE1)-LaxWendroffSlope(i+1,ebin,i0)*ElossRate_e2*(ebin-deltaE2));
+        value -= lw;*/
+        
+        /* Comment the next lines until the curly bracket if the
+         * Lax-Wendroff slope limiter is used.                   */
         mm =  0.5*quot * (GetMinModSlope(i, ebin, i0) * ElossRate_e1 *
                                  (ebin - deltaE1) -
                              GetMinModSlope(i + 1, ebin, i0) * ElossRate_e2 *
                                  (ebin - deltaE2));
-        double lw = 0.5*quot*(LaxWendroffSlope(i,ebin,i0)*ElossRate_e1*(ebin-deltaE1)-LaxWendroffSlope(i+1,ebin,i0)*ElossRate_e2*(ebin-deltaE2));
         sb =
             0.5*quot*(GetSuperBeeSlope(i,ebin,i0)*ElossRate_e1*(ebin-deltaE1)-GetSuperBeeSlope(i+1,ebin,i0)*ElossRate_e2*(ebin-deltaE2));
-        //value -= lw; //uncomment line if LaxWendroff is used
-        value -= 0.5 * sqrt(mm*mm + sb*sb); //comment if LaxWendroff is used
+        value -= 0.5 * sqrt(mm*mm + sb*sb);
       }
 
       //TODO: get slope limiter right in case of adiabatic heating!

--- a/src/Particles.C
+++ b/src/Particles.C
@@ -889,13 +889,18 @@ void Particles::ComputeGrid(vector<double> EnergyAxis, double startTime,
       /* slope limiters (per default enabled, toggle on/off with FASTMODE flag) */    
       if(FASTMODE == false) {
         double mm,sb;
-        mm = 0.5 * quot * (GetMinModSlope(i, ebin, i0) * ElossRate_e1 *
+        mm =  quot * (LaxWendroffSlope(i, ebin, i0) * ElossRate_e1 *
+                (ebin - deltaE1) -
+                             LaxWendroffSlope(i + 1, ebin, i0) * ElossRate_e2 *
+                                 (ebin - deltaE2));
+        /*mm =  0.5*quot * (GetMinModSlope(i, ebin, i0) * ElossRate_e1 *
                                  (ebin - deltaE1) -
                              GetMinModSlope(i + 1, ebin, i0) * ElossRate_e2 *
-                                 (ebin - deltaE2));
+                                 (ebin - deltaE2));*/
+        double lw = 0.5*quot*(LaxWendroffSlope(i,ebin,i0)*ElossRate_e1*(ebin-deltaE1)-LaxWendroffSlope(i+1,ebin,i0)*ElossRate_e2*(ebin-deltaE2));
         sb =
             0.5*quot*(GetSuperBeeSlope(i,ebin,i0)*ElossRate_e1*(ebin-deltaE1)-GetSuperBeeSlope(i+1,ebin,i0)*ElossRate_e2*(ebin-deltaE2));
-        value -= 0.5 * sqrt(mm*mm + sb*sb);
+        value -= lw; // 0.5 * sqrt(mm*mm + sb*sb);
       }
 
       //TODO: get slope limiter right in case of adiabatic heating!
@@ -977,6 +982,13 @@ double Particles::GetSuperBeeSlope(int i, double deltaX, int i0) {
   double sigma = MaxMod(sigma1, sigma2);
   return sigma;
 }
+
+
+double Particles::LaxWendroffSlope(int i, double deltaX, int i0) {
+  double sigma = (grid[i0][i] - grid[i0][i+1])/ deltaX;
+  return sigma;
+}
+
 
 /** MaxMod function for slope limiters */
 double Particles::MaxMod(double a, double b) {

--- a/src/Particles.C
+++ b/src/Particles.C
@@ -889,18 +889,21 @@ void Particles::ComputeGrid(vector<double> EnergyAxis, double startTime,
       /* slope limiters (per default enabled, toggle on/off with FASTMODE flag) */    
       if(FASTMODE == false) {
         double mm,sb;
-        mm =  quot * (LaxWendroffSlope(i, ebin, i0) * ElossRate_e1 *
+        // uncomment the following def. for Lax-Wendroff slope limiter
+        /*mm =  quot * (LaxWendroffSlope(i, ebin, i0) * ElossRate_e1 *
                 (ebin - deltaE1) -
                              LaxWendroffSlope(i + 1, ebin, i0) * ElossRate_e2 *
-                                 (ebin - deltaE2));
-        /*mm =  0.5*quot * (GetMinModSlope(i, ebin, i0) * ElossRate_e1 *
+                                 (ebin - deltaE2));*/
+        //Comment this line if Lax-Wendroff is used
+        mm =  0.5*quot * (GetMinModSlope(i, ebin, i0) * ElossRate_e1 *
                                  (ebin - deltaE1) -
                              GetMinModSlope(i + 1, ebin, i0) * ElossRate_e2 *
-                                 (ebin - deltaE2));*/
+                                 (ebin - deltaE2));
         double lw = 0.5*quot*(LaxWendroffSlope(i,ebin,i0)*ElossRate_e1*(ebin-deltaE1)-LaxWendroffSlope(i+1,ebin,i0)*ElossRate_e2*(ebin-deltaE2));
         sb =
             0.5*quot*(GetSuperBeeSlope(i,ebin,i0)*ElossRate_e1*(ebin-deltaE1)-GetSuperBeeSlope(i+1,ebin,i0)*ElossRate_e2*(ebin-deltaE2));
-        value -= lw; // 0.5 * sqrt(mm*mm + sb*sb);
+        //value -= lw; //uncomment line if LaxWendroff is used
+        value -= 0.5 * sqrt(mm*mm + sb*sb); //comment if LaxWendroff is used
       }
 
       //TODO: get slope limiter right in case of adiabatic heating!

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -659,7 +659,7 @@ double Radiation::ICEmissivityAnisotropicFirstIntegral(double x, void *par) {
             cos_zeta = cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
             if (cos_zeta < cos_zeta_min) continue;
 
-            
+        /*    
             // Kinematic limits from sec. 2.2.1.
             double upsilon = (cos_zeta_min+cos_kappa*cos(theta)) / (sin_kappa*sin(theta));
             if (std::isinf(upsilon) || std::isnan(upsilon)) continue;
@@ -672,7 +672,7 @@ double Radiation::ICEmissivityAnisotropicFirstIntegral(double x, void *par) {
                 if(upsilon > 0.) continue;
                 if(upsilon < 0. && fabs(phi-phi_el) > pi) continue;
             }
-        
+        */
             Q = interp2d_spline_eval(*TargetPhotonAngularDistrCurrent, 
                                      phi, theta, *phiaccescCurrent,*thetaaccescCurrent);
             double eph_d = ephoton/m_e * lorentz * (1. + beta*cos_zeta);

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -655,8 +655,8 @@ double Radiation::ICEmissivityAnisotropicFirstIntegral(double x, void *par) {
         for (double theta = theta_min; theta <= theta_max; theta += d_theta) {
 
 
-            //cos_zeta = -cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
-            cos_zeta = cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
+            cos_zeta = -cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
+            //cos_zeta = cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
             if (cos_zeta < cos_zeta_min) continue;
 
         /*    

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -655,8 +655,8 @@ double Radiation::ICEmissivityAnisotropicFirstIntegral(double x, void *par) {
         for (double theta = theta_min; theta <= theta_max; theta += d_theta) {
 
 
-            cos_zeta = -cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
-            //cos_zeta = cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
+            //cos_zeta = -cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
+            cos_zeta = cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
             if (cos_zeta < cos_zeta_min) continue;
 
             

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -401,10 +401,10 @@ double Radiation::ICEmissivityRadFieldIntegrated(double x, void *par) {
   if(ANISOTROPY_CURRENT == true)  {
     if(ISOTROPIC_ELECTRONS){
 //      if(ISOTROPIC_ELECTRONS && (!USE_AHARONIAN)) {
-//        IntFunc = &Radiation::ICEmissivityAnisotropicIsotropicElectrons;
+        IntFunc = &Radiation::ICEmissivityAnisotropicIsotropicElectrons;
 //    }
 //    else if(ISOTROPIC_ELECTRONS){  //&& USE_AHARONIAN){
-        IntFunc = &Radiation::ICEmissivityAnisotropicIsotropicElectronsAharonian;
+//        IntFunc = &Radiation::ICEmissivityAnisotropicIsotropicElectronsAharonian;
     }
     else {
         IntFunc = &Radiation::ICEmissivityAnisotropic;
@@ -638,8 +638,8 @@ double Radiation::ICEmissivityAnisotropicFirstIntegral(double x, void *par) {
     
     double beta = sqrt(1. - 1. / (lorentz*lorentz));
     double Q = 0.; double F = 0.; double cos_zeta = 0.;
-    double cos_zeta_min = egamma/(2.*ephoton*lorentz*(lorentz-egamma/c_speed))-1.; 
-
+    //double cos_zeta_min = egamma/(2.*ephoton*lorentz*(lorentz-egamma/c_speed))-1.; 
+    double cos_zeta_min = egamma/(2.*ephoton*lorentz*(lorentz-egamma/m_e))-1.;
 
     double zeta_min = acos(cos_zeta_min);
     double integral = 0.;
@@ -656,11 +656,12 @@ double Radiation::ICEmissivityAnisotropicFirstIntegral(double x, void *par) {
 
 
             cos_zeta = -cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
-
+            //cos_zeta = cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
             if (cos_zeta < cos_zeta_min) continue;
 
+            
             // Kinematic limits from sec. 2.2.1.
-            double upsilon = cos_zeta_min+cos_kappa*cos(theta) / (sin_kappa*sin(theta));
+            double upsilon = (cos_zeta_min+cos_kappa*cos(theta)) / (sin_kappa*sin(theta));
             if (std::isinf(upsilon) || std::isnan(upsilon)) continue;
             if(fabs(theta - pi_min_ka) > zeta_min) { continue;}
             if (fabs(upsilon) < 1.) {

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -13,6 +13,7 @@ Radiation::Radiation() {
   IC_CALCULATED = false;
   SSCSET = false;
   ANISOTROPY_CURRENT = false;
+  ISOTROPIC_ELECTRONS = false;  //If true, calculate anisotropip IC scattering with isotropic electrons
   lumtoflux = 0.;
   ldiffbrems = fdiffbrems = ldiffsynch = fdiffsynch = 0.;
   ldiffic = fdiffic = ldiffpp = fdiffpp = 0.;
@@ -397,7 +398,12 @@ double Radiation::ICEmissivityRadFieldIntegrated(double x, void *par) {
   double integratorTolerance_IC = integratorTolerance;
   int kronrod = 6; 
   if(ANISOTROPY_CURRENT == true)  {
-    IntFunc = &Radiation::ICEmissivityAnisotropic;
+    if(ISOTROPIC_ELECTRONS) {
+        IntFunc = &Radiation::ICEmissivityAnisotropicIsotropicElectrons;
+    }
+    else {
+        IntFunc = &Radiation::ICEmissivityAnisotropic;
+    }
     integratorTolerance_IC = integratorTolerance*5;
     kronrod = 2;
   }
@@ -558,6 +564,154 @@ double Radiation::ICEmissivityAnisotropic(double x, void *par) {
 //    std::cout<<"-------------------------------------"<<std::endl;
     return integrand;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+/*-------------------------------------------------------------------------------------------------------
+ *      This Block calculates the Anisotropic IC emission for isotropic electrons
+ * 
+ *------------------------------------------------------------------------------------------------------*/
+
+
+// Returns the over all electron angles integrated Anisotropic emission
+double Radiation::ICEmissivityAnisotropicIsotropicElectrons(double x, void *par){
+    double normalization = 4*pi;
+    double ephoton = pow(10.,x);  ///< energy of the target photon
+    double *p = (double *)par;
+    double lorentz = p[0] / m_e;
+    double egamma = p[1];  ///< energy of the resulting gamma photon
+    double integral;
+    
+    fPointer theta_int_function = &Radiation::ICEmissivityAnisotropicSecondIntegral;
+    
+    double integralinput[3];
+    integralinput[0] = lorentz;
+    integralinput[1] = egamma;
+    integralinput[2] = ephoton;
+    
+    integral = Integrate(theta_int_function, integralinput, 0.0, 1.0*pi, integratorTolerance*5,
+                         2);
+    
+    return (integral/normalization);
+    
+}
+
+
+
+double Radiation::ICEmissivityAnisotropicSecondIntegral(double x, void *par) {
+    double theta_el = x;   // Phi electron angle for integration
+    double *p = (double *)par;
+    double ephoton = pow(10.,p[2]);  ///< energy of the target photon
+    double lorentz = p[0] / m_e;
+    double egamma = p[1];  ///< energy of the resulting gamma photon
+    double integral;
+    fPointer phi_int_function = &Radiation::ICEmissivityAnisotropicFirstIntegral;
+    
+    double integralinput[4];
+    integralinput[0] = lorentz;
+    integralinput[1] = egamma;
+    integralinput[2] = ephoton;
+    integralinput[3] = theta_el;
+    
+    
+    
+    integral = Integrate(phi_int_function, integralinput,0.0, 2.0*pi,integratorTolerance*5,
+                         2);
+    return integral;
+}
+    
+  
+
+
+// Function to integrate over phi-angle of electrons
+double Radiation::ICEmissivityAnisotropicFirstIntegral(double x, void *par) {
+    double phi_el = x;   // Phi electron angle for integration
+    double *p = (double *)par;
+    double lorentz = p[0] / m_e;
+    double egamma = p[1];  ///< energy of the resulting gamma photon
+    double ephoton = pow(10.,p[2]);  ///< energy of the target photon
+    double theta_el = p[3];
+    
+    double beta = sqrt(1. - 1. / (lorentz*lorentz));
+    double Q = 0.; double F = 0.; double cos_zeta = 0.;
+    double cos_zeta_min = egamma/(2.*ephoton*lorentz*(lorentz-egamma/c_speed))-1.; 
+
+
+    double zeta_min = acos(cos_zeta_min);
+    double integral = 0.;
+    double cos_kappa = cos(theta_el); double sin_kappa = sin(theta_el);   
+    double pi_min_ka = pi - theta_el; 
+
+    double phi_min = (*TargetPhotonAngularBoundsCurrent)[0];
+    double phi_max = (*TargetPhotonAngularBoundsCurrent)[1];
+    double theta_min = (*TargetPhotonAngularBoundsCurrent)[2];
+    double theta_max = (*TargetPhotonAngularBoundsCurrent)[3];
+    for (double phi = phi_min; phi <= phi_max; phi += d_phi) {
+
+        for (double theta = theta_min; theta <= theta_max; theta += d_theta) {
+
+
+            cos_zeta = -cos_kappa *cos(theta) + sin_kappa * sin(theta) * cos(phi - phi_el);
+
+            if (cos_zeta < cos_zeta_min) continue;
+
+            // Kinematic limits from sec. 2.2.1.
+            double upsilon = cos_zeta_min+cos_kappa*cos(theta) / (sin_kappa*sin(theta));
+            if (std::isinf(upsilon) || std::isnan(upsilon)) continue;
+            if(fabs(theta - pi_min_ka) > zeta_min) { continue;}
+            if (fabs(upsilon) < 1.) {
+                
+                if(fabs(phi - phi_el) > acos(upsilon)) continue;
+            }            
+            else {
+                if(upsilon > 0.) continue;
+                if(upsilon < 0. && fabs(phi-phi_el) > pi) continue;
+            }
+        
+            Q = interp2d_spline_eval(*TargetPhotonAngularDistrCurrent, 
+                                     phi, theta, *phiaccescCurrent,*thetaaccescCurrent);
+            double eph_d = ephoton/m_e * lorentz * (1. + beta*cos_zeta);
+            if (egamma/m_e > 2. * lorentz * eph_d / (1. + 2.*eph_d)) continue;
+
+            F = ICAnisotropicAuxFunc(phi,theta,ephoton,egamma,lorentz,beta,cos_zeta);
+            integral += sin(theta) * d_phi * d_theta * F * Q;
+            
+        }
+    }
+
+    double targetphotons = fUtils->EvalSpline(x,
+                                              *TargetPhotonLookupCurrent,
+                                              *TargetAccCurrent,__func__,__LINE__);
+    double integrand = pi * e_radius * e_radius * c_speed;
+    integrand /= ephoton * (lorentz-egamma/m_e) * (lorentz-egamma/m_e);
+    integrand *= integral * pow(10.,targetphotons);
+    integrand *= ln10 * ephoton;
+    return (sin(theta_el)*integrand);
+}
+
+
+
+
+
+
+//--------------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------------
+
+
+
+
+
+
+
 
 void Radiation::FillCosZetaLookup(int i) {
     vector <vector<double> > v;
@@ -1851,6 +2005,19 @@ void Radiation::SetTargetPhotonAnisotropy(int i, vector<double> obs_angle,
 
     return;
 }
+
+
+
+/* Function to set an isotropic electron distribution for the case of   *
+ * anisotropic inverse Compton scattering                               */
+void Radiation::SetElectronsIsotropic(void){
+    ISOTROPIC_ELECTRONS = true;
+}
+
+
+
+
+
 
 vector< vector<double> > Radiation::GetTargetPhotonAnisotropy(int i, 
                                      vector<double> phi, vector<double> theta) { 

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -689,14 +689,17 @@ double Radiation::ICEmissivityAnisotropicIsotropicElectronsFirstIntegral(double 
 
 void Radiation::FillCosZetaLookup(int i) {
     vector <vector<double> > v;
+
     double phi_min = TargetPhotonAngularBounds[i][0];
     double phi_max = TargetPhotonAngularBounds[i][1];
     double theta_min = TargetPhotonAngularBounds[i][2];
     double theta_max = TargetPhotonAngularBounds[i][3];
+
     double ph_ma = phi_max+0.1*fabs(phi_max); double ph_mi = phi_min-0.1*fabs(phi_min);
     double th_ma = theta_max+0.1*fabs(theta_max); double th_mi = theta_min-0.1*fabs(theta_min);
     double d_ph = 0.25*d_phi;
     double d_th = 0.25*d_theta;
+
     for (double theta = th_mi; theta <= th_ma; theta += d_th) {
         for (double phi = ph_mi; phi <= ph_ma; phi += d_ph) {
             double sin_phi = sin(phi); double cos_phi = cos(phi);
@@ -1950,9 +1953,12 @@ void Radiation::SetTargetPhotonAnisotropy(int i, vector<double> obs_angle,
     d_phi = phi[1]-phi[0];
     d_theta = theta[1]-theta[0];
 
+    
     // now set the target field anisotropy map
     vector< vector<double> > ani = fUtils->MeshgridToTwoDVector(phi,theta,mesh);
+
     vector<double> extrema = fUtils->GetVectorMinMax(ani,2);
+
     ani_minval = extrema[0];
     ani_maxval = extrema[1];
     TargetPhotonAngularDistrs[i] = 
@@ -1963,18 +1969,16 @@ void Radiation::SetTargetPhotonAnisotropy(int i, vector<double> obs_angle,
     TargetPhotonAngularBounds[i].push_back(theta_max);
     TargetPhotonAngularBounds[i].push_back(ani_minval);
     TargetPhotonAngularBounds[i].push_back(ani_maxval);
-    
+
     TargetPhotonAngularDistrsVectors[i] = mesh;
     TargetPhotonAngularPhiVectors[i] = phi;
     TargetPhotonAngularThetaVectors[i] = theta;
-
 
     phiaccescs[i] = gsl_interp_accel_alloc();
     thetaaccescs[i] = gsl_interp_accel_alloc();
     phiaccesc_zetas[i] = gsl_interp_accel_alloc();
     thetaaccesc_zetas[i] = gsl_interp_accel_alloc();
-
-    FillCosZetaLookup(i);
+    //FillCosZetaLookup(i);
     ANISOTROPY[i] = true;
     
     if ( distance == 0.0 ){


### PR DESCRIPTION
Implementation of equ.  20 from Aharonian&Atoyan 1981.
The anisotropic target photon field can be set as before with
SetTargetPhotonAnisotropy(int i, vector<double> obs_angle, vector<double> phi, vector<double> theta, vector< vector<double> > mesh)
Calling the function SetElectronsIsotropic(void) sets the variable ISOTROPIC_ELECTRONS to true and the emission is calculated for an isotropic electron distribution when the function CalculateDifferentialPhotonSpectrum is executed.