### PR TITLE
Fix build with SWIG v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,9 @@ libgamera : $(objectsSO)
 
 # make gappa package
 gappa:
-	cd python;\
-	swig -python -c++ -nosafecstrings -outdir ../lib -o _gappa.cc gappa.i;\
-	python setup.py build_ext --build-lib ../lib;\
-	cd ..;\
+	cd python && \
+	swig -python -c++ -nosafecstrings -outdir ../lib -o _gappa.cc gappa.i && \
+	python setup.py build_ext --build-lib ../lib
 
 
 clean-out:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ libgamera : $(objectsSO)
 # make gappa package
 gappa:
 	cd python && \
-	swig -python -c++ -nosafecstrings -outdir ../lib -o _gappa.cc gappa.i && \
+	swig -python -c++ -outdir ../lib -o _gappa.cc gappa.i && \
 	python setup.py build_ext --build-lib ../lib
 
 


### PR DESCRIPTION
The option `-nosafecstrings` has been removed in SWIG v4. We should aim to support this version because it is the default on Homebrew and the first one to be compatible with Python 3.8.

The option might have been added as an attempt to optimise performance in the first place (although `-nosafecstrings` was actually the default for all prior versions, cf. http://www.swig.org/Release/CHANGES). If this is needed we should consider passing the `-O` flag instead – this shouldn't cause problems as it has been introduced at the same time as `-nosafecstrings`.

@Carlor87 @MischaBr Please let me know if this branch tests okay on your systems and if we should add the `-O` flag as well.