### PR TITLE
Fixpartclass ion d200930

### DIFF
--- a/include/Particles.h
+++ b/include/Particles.h
@@ -85,7 +85,7 @@ struct timespec time0, time1, time2, time3;
   double TminLookup;    ///< Lower time bound of custom injection lookup.
   double TmaxLookup;    ///< Higher time bound of custom injection lookup.
   double BField;        ///< amplified B-field immediately dowmstream
-  double N;             ///< ambient density
+  double N;             ///< ambient density (only refers to protons. Assumes additional 10% of it as Helium)
   double R;             ///< source extension (cm)
   double V;             ///< source expansion velocity (cm/s)
   double Lum;           ///< energy injection rate at a given time
@@ -241,8 +241,8 @@ struct timespec time0, time1, time2, time3;
                                          ///linear advection algorithm,
                                          ///optionally with the 'Superbee'-Slope
                                          ///limiter
-  void FillEnergyTrajectoryLookup();
-  double CalcSpecSemiAnalyticConstELossIntegrand(double *x, double *par);
+  //void FillEnergyTrajectoryLookup();  ///NOT DEFINED
+  //double CalcSpecSemiAnalyticConstELossIntegrand(double *x, double *par);  ///NOT DEFINED
   void CalcSpecSemiAnalyticConstELoss();
   void CalcSpecSemiAnalyticNoELoss();
   double MaxMod(double a,
@@ -276,10 +276,10 @@ struct timespec time0, time1, time2, time3;
                                    ///EmaxConstant)
   bool QUIETMODE;  ///< Quietmode boolean: no output text at all if set to true
                    ///. Default is false.
-  double Polynomial(double x, vector<double>);  ///< polynomial function, used
+  // double Polynomial(double x, vector<double>);  ///< polynomial function, used
                                                 ///for deriving systematic
                                                 ///errors due to numerical
-                                                ///wiggling.
+                                                ///wiggling. NOT DEFINED
   void CalculateConstants();  ///< speed hack where often used constants are
                               ///calculated ahead of the grid solving
   double PowerLawInjectionSpectrum(double e, double ecut,
@@ -288,7 +288,7 @@ struct timespec time0, time1, time2, time3;
                                                   ///SpectralIndex2 are
                                                   ///specified, returns a broken
                                                   ///power law.
-  double InverseLossRate(double *x, double *par);
+  // double InverseLossRate(double *x, double *par);   ///NOT DEFINED
   void SetLookup(vector<vector<double> > v, string LookupType);  ///<Sets lookup for evolution
   void ExtendLookup(vector<vector<double> > v, string LookupType);
   double SemiAnalyticConstELossIntegrand(double T, void *par);
@@ -322,288 +322,644 @@ struct timespec time0, time1, time2, time3;
   void CalculateParticleSpectrum(string type = "electrons", int bins = 100,
                                  bool onlyprepare = false,
                                  bool dontinitialise = false); ///< fill the
-                                                        ///lookup that holds
-                                                    ///the particle spectrum.
+                                                               ///lookup that holds
+                                                               ///the particle spectrum.
  public:
+  /// Default constructor
   Particles();
+  /// Default destructor
   ~Particles();
-  void SetMembers(double t);  ///< set the values for the class variables
-                              ///BField,eElectronMax and Ecr at a given time t
-
+  /// Set important class members to values at time t [yr]
+  void SetMembers(double t);
+  /**
+   * @short Calculate proton spectrum (units erg, erg^-1)
+   * @param bins is the number of bins in the specral lookup (default 100)
+   *
+   * This is a wrapper around private member Particles::CalculateParticleSpectrum
+   */
   void CalculateProtonSpectrum(int bins = 100) {CalculateParticleSpectrum("protons",bins);}
+  /**
+   * @short Calculate electron spectrum (units erg, erg^-1)
+   * @param bins is the number of bins in the spectral lookup (default 100)
+   *
+   * This is a wrapper around private member Particles::CalculateParticleSpectrum
+   */
   void CalculateElectronSpectrum(int bins = 100) {CalculateParticleSpectrum("electrons",bins);}
+  /**
+   * @short Calculate proton spectrum (units erg, erg^-1) only between
+   * time T1 and T2.
+   *
+   * @param T1 initial time for calculation
+   * @param T2 end time for calculation
+   * @param bins is the number of bins in the spectral lookup (default 100)
+   *
+   * This is a wrapper around private member Particles::ComputeGridInTimeInterval
+   */
   void CalculateProtonSpectrumInTimeInterval(double T1, double T2,
                                              int bins = 100) {
     ComputeGridInTimeInterval(T1,T2,"protons",bins,false);}
+  /**
+   * @short Calculate electron spectrum (units erg, erg^-1) only between
+   * time T1 and T2.
+   *
+   * @param T1 initial time for calculation
+   * @param T2 end time for calculation
+   * @param bins is the number of bins in the spectral lookup (default 100)
+   * @param ICRESET to reset the inverse Compton lookups (default false)
+   * setting ICRESET to true can be useful for radiation fields that change with time.
+   *
+   * This is a wrapper around private member Particles::ComputeGridInTimeInterval
+   */
   void CalculateElectronSpectrumInTimeInterval(double T1, double T2,
                                                int bins = 100, bool ICRESET=false) {
     ComputeGridInTimeInterval(T1,T2,"electrons",bins,ICRESET);}
-  void CalculateElectronSpectrumInTimeInterval(int bins = 100) {CalculateParticleSpectrum("electrons",bins);}
-  void SetType(string type);  ///< Set the particle type ("protons" or "electrons")
-  double EnergyLossRate(double E);  ///< total energy loss rate of particles
+  /// Set the particle type ("protons" or "electrons")
+  void SetType(string type);
+  /// Calculate energy loss rate of particle with energy E (erg)
+  double EnergyLossRate(double E);
+  /**
+   * @short Enable the calculation of the ionization losses
+   *
+   * This is because normally we consider fully ionized plasma
+   * if you really want to compute ionization losses, call this function
+   * after the defining the class
+   */
   void SetIonization() {
 	  IONIZATION = true;
-  }  ///< Set the calculation of the ionization. This is because normally we consider fully ionized plasma
-     /// if you really want to compute ionization losses, call this function
+  }
+  /// Unset ionization losses
   void UnsetIonization() {
 	  IONIZATION = false;
-  }  ///< Unset accounting for ionization losses.
+  }
+  /// Set the age of the system. @param age in years
   void SetAge(double age) {
     Age = age;
     SetMembers(Age);
-  }                                      ///< set source age
-  double GetAge() const { return Age; }  ///< get source age
+  }
+  /// Return age of the system
+  double GetAge() const { return Age; }
+  /// Return particle luminosity of the source (erg/s)
   double GetLuminosity(double age=0.) {
     if(age) SetMembers(age);
     CalculateConstants();
     return Lum;
-  }  ///< get particle luminosity of the source
+  }
+  /// Return the magnetic field at the site.
   double GetBField(double age=0.) {
     if(age) SetMembers(age);
     CalculateConstants();
     return BField;
-  }  ///< get the BField at the acceleration site of the astrophysical particle
-     ///accelerator.
+  }
+  /**
+   * @short Return the proton ambient density at the astrophysical particle accelerator (cm^-3).
+   * The returned value is for the proton density. So far there is an implicit
+   * assumption of an additional 10% of Helium
+   */
   double GetAmbientDensity(double age=0.) {
     if(age) SetMembers(age);
     CalculateConstants();
     return N;
-  }  ///< get the ambient density at the astrophysical particle accelerator.
+  }
+  /// Return the extension of the astrophysical particle accelerator (pc).
   double GetRadius(double age=0.) {
     if(age) SetMembers(age);
-/*    CalculateConstants();*/
     return R/pc_to_cm;
-  }  ///< get the extension of the astrophysical particle accelerator (cm).
+  }
+  /// Return the extension speed of the astrophysical particle accelerator (cm/s).
   double GetExpansionVelocity(double age=0.) {
     if(age) SetMembers(age);
     CalculateConstants();
     return V;
-  }  ///< get the extension speed of the astrophysical particle accelerator
-     ///(cm/s).
+  }
+  /// Return the maximum particle energy (erg)
   double GetEmax(double age=0.) {
     if(age) SetMembers(age);
     CalculateConstants();
-    return eMax; }  ///< get the max. particle energy (erg)
+    return eMax; }
+  /// Return the particle escape time scale (s) for particle of energy e (in erg)
   double GetEscapeTime(double e, double age=0.) {
     if(age) SetMembers(age);
     CalculateConstants();
     return EscapeTime(e,age) / yr_to_sec;
-  }  ///< the particle escape time scale (s)
+  }
+  /// @overload Return the particle escape time scale (s) for energy vector (energy in erg)
   vector < vector<double> > GetEscapeTime(vector<double> epoints, double age=0.) {
       return GetQuantityVector(epoints,age,"escape_time");
-  } ///< the particle escape time scale (s), returns spectral shape
+  }
+  /// Switch on Debugging/Testing mode
   void ToggleDebugging() {
     DEBUG = true;
-  }  ///< switch on Debugging/Testing mode
+  }
+  /// Set the lookup holding energy-dependent IC cooling rate {E-ICLossRate}
   void SetICLossLookup(vector<vector<double> > ICLOSSLOOKUP) {
     SetLookup(ICLOSSLOOKUP, "ICLoss");
-  }  ///< set the lookup holding energy-dependent IC cooling rate {E-ICLossRate}
-
+  }
+  /// Set ambient density time evolution lookup (units of cm^-3)
   void SetAmbientDensity(vector<vector<double> > NLOOKUP) {
     NConstant = NAN;
     SetLookup(NLOOKUP, "AmbientDensity");
-  }  ///< Set ambient density evolution
+  }
+  /// Set BField time evolution lookup (units of gauss)
   void SetBField(vector<vector<double> > BFIELDLOOKUP) {
     BConstant = NAN;
     SetLookup(BFIELDLOOKUP, "BField");
-  }  ///< Set BField evolution
-
+  }
+  /// Set radius time evolution loookup (units of pc)
   void SetRadius(vector<vector<double> > RADIUSLOOKUP) {
     RConstant = NAN;
     SetLookup(RADIUSLOOKUP, "Radius");
-  }  ///< Set radius evolution
-
+  }
+  /// Set expansion velocity time evolution lookup (units of cm/s)
   void SetExpansionVelocity(vector<vector<double> > VELOCITYLOOKUP) {
     VConstant = NAN;
     SetLookup(VELOCITYLOOKUP, "Speed");
-  }  ///< Set expansion velocity evolution
+  }
 
+  /**
+   * @short Set the luminosity evolution lookup
+   *
+   * @param vector of 2D tuples (time, luminosity) [yr] and [erg/s]
+   */
   void SetLuminosity(vector<vector<double> > LUMLOOKUP) {
     LumConstant = NAN;
     SetLookup(LUMLOOKUP, "Luminosity");
-  }  ///< DEPRECATED
-
+  }
+  /**
+   * @short Extend the lookup holding energy-dependent IC cooling rate {E-ICLossRate}
+   *
+   * See Particles::SetICLossLookup
+   */
   void ExtendICLossLookup(vector<vector<double> > ICLOSSLOOKUP) {
     ExtendLookup(ICLOSSLOOKUP, "ICLoss");
-  }  ///< set the lookup holding energy-dependent IC cooling rate {E-ICLossRate}
+  }
+  /**
+   * @short Extend the luminosity evolution lookup. DEPRECATED
+   *
+   * See Particles::SetLuminosity
+   */
   void ExtendLuminosityLookup(vector<vector<double> > LUMLOOKUP) {
     ExtendLookup(LUMLOOKUP, "Luminosity");
-  }  ///< Set BField evolution
+  }
+  /**
+   * @short Extend the ambient density time evolution lookup
+   *
+   * See Particles::SetAmbientDensity
+   */
   void ExtendAmbientDensityLookup(vector<vector<double> > NLOOKUP) {
     ExtendLookup(NLOOKUP, "AmbientDensity");
-  }  ///< Set ambient density evolution
+  }
+  /**
+   * @short Extend the Bfield time evolution lookup
+   *
+   * See Particles::SetBField
+   */
   void ExtendBFieldLookup(vector<vector<double> > BFIELDLOOKUP) {
     ExtendLookup(BFIELDLOOKUP, "BField");
-  }  ///< Set BField evolution
+  }
+  /// Set or extend the maximum energy time evolution
   void ExtendEmaxLookup(vector<vector<double> > EMAXLOOKUP) {
     ExtendLookup(EMAXLOOKUP, "Emax");
-  }  ///< Set max. particle evolution
+  }
+  /// Set or extend the escape-time time evolution
   void ExtendEscapeTimeLookup(vector<vector<double> > ESCTIMELOOKUP) {
     ExtendLookup(ESCTIMELOOKUP, "EscapeTime");
-  }  ///< Set escape time evolution
+  }
+  /**
+   * @short Extend the Radius time evolution lookup
+   *
+   * See Particles::SetRadius
+   */
   void ExtendRadiusLookup(vector<vector<double> > RLOOKUP) {
     ExtendLookup(RLOOKUP, "Radius");
-  }  ///<
+  }
+  /**
+   * @short Extend the expansion-velocity time evolution lookup
+   *
+   * See Particles::SetExpansionVelocity
+   */
   void ExtendVelocityLookup(vector<vector<double> > VLOOKUP) {
     ExtendLookup(VLOOKUP, "Speed");
-  }  ///<
+  }
 /*  vector<vector<double> > GetICLossLookup() { return ICLossVector; }*/
+  /// Return Luminosity lookup (erg/s vs. yrs)
   vector<vector<double> > GetLuminosityLookup() {
     return fUtils->VectorAxisPow10(LumVector,1);
   }
+  /// Return Maximum energy lookup (erg vs yrs)
   vector<vector<double> > GetEmaxLookup() {
     return fUtils->VectorAxisPow10(eMaxVector,1);
   }
+  /// Return Magnetic field lookup (G vs yrs)
   vector<vector<double> > GetBFieldLookup() {return BVector; }
+  /// Return Radius lookup (pc vs yrs)
   vector<vector<double> > GetRadiusLookup() {return RVector; }
+  /// Return expansion-velocity lookup (cm/s vs yrs)
   vector<vector<double> > GetVelocityLookup() {return VVector; }
+  /**
+   *  @short Return energy loss rate of a particle
+   *
+   *  Options for the loss process depend on the environment parameters
+   *  that have been initializated:
+   *   - sum  = all the losses introduced
+   *   - adiabatic_losses : both particles, requires expansion velocity
+   *   - synchrotron : electrons only, requires initialization of a B field
+   *   - bremsstrahlung : electrons only, requires initialization of an ambient density
+   *   - inverse_compton : electrons only, requires initialization of a target photon field
+   *   - ionization : protons only, requires setting the ionization losses and ambient density
+   *   - ppcol : proton-proton scattering. Protons only, requires ambient density
+   *
+   *  @param E the energy of the particle in erg
+   *  @param type the loss process
+   *  @param age (optional) age at which to compute the losses
+   *
+   *  @return loss rate in erg/s
+   */
   double GetEnergyLossRate(double E, string type,double age=0.);
-  double GetCoolingTimeScale(double E, string type="sum", double age=0.) {//< this gives the cooling time scale at E and time age in [years]
+  /** Return the cooling time scale at energy E [erg] and time age in [years]
+   *
+   * @param E : energy of the particle in erg
+   * @param type : type of loss process (see Particles::GetEnergyLossRate)
+   * @param age : age of the system for calculation [yrs] (default = 0)
+   * @return energy loss rate in erg/s
+   */
+  double GetCoolingTimeScale(double E, string type="sum", double age=0.) {
       return  E / GetEnergyLossRate(E,type) / yr_to_sec; }
-
+  /// @overload
   vector< vector<double> > GetEnergyLossRate(vector<double> epoints, string type="sum",
                                                             double age=0.) {
       return GetEnergyLossRateVector(epoints,type,age,false);
   }
+  /// @overload
   vector< vector<double> > GetCoolingTimeScale(vector<double> epoints, string type="sum",
                                                double age=0.) {
       return GetEnergyLossRateVector(epoints,type,age,true);
   }
+  /**
+   * @short Return the differential injection particle spectrum
+   * as E[TeV] vs dN/dE[erg^-1]
+   *
+   * Wrapper around Particles::GetInjectionSpectrumVector
+   *
+   * @param epoints : vector of energy points in units of erg
+   * @param age : age of the system in years (default 0)
+   * @return particle spectrum in E [TeV] vs dN/dE [erg^-1] as vector of 2D tuples
+   */
   vector< vector<double> > GetInjectionSpectrum(vector<double> epoints, double age=0.) {
       return GetInjectionSpectrumVector(epoints,age,false);
   }
+  /**
+   * @short Return the spectral energy distribution of the
+   * injection particle spectrum as E[TeV] vs E^2dN/dE[erg]
+   *
+   * Wrapper around Particles::GetInjectionSpectrumVector
+   *
+   * @param epoints : vector of energy points in units of erg
+   * @param age : age of the system in years (default 0)
+   * @return particle spectrum in E [TeV] vs E^2dN/dE [erg] as vector of 2D tuples
+   */
   vector< vector<double> > GetInjectionSED(vector<double> epoints, double age=0.) {
       return GetInjectionSpectrumVector(epoints,age,true);
   }
+  /**
+   * @short Returns a quantity vector depending on the parameter \a mode
+   *
+   * Options available for \a mode:
+   *  - energy_loss_rate
+   *  - cooling_time_scale
+   *  - injection_spectrum
+   *  - injection_sed
+   *  - escape_time
+   *
+   * @param epoints : vector of energy points in units of erg
+   * @param age : age of the system in years (default 0)
+   * @param mode : quantity to return
+   * @return vector of 2D tuples of the \a mode quantity.
+   */
   vector< vector<double> > GetQuantityVector(vector<double> epoints,
                                                       double age, string mode);
+  /// Get energy binning of the numerical solution
   double GetEnergyBins() {
     return ebins;
-  }  ///< get energy binning of the numerical solution
+  }
+  /// Get vector that holds source particle spectrum
   vector<vector<double> > GetParticleSpectrum() {
     return ParticleSpectrum;
-  }  ///< get vector that holds source particle spectrum
+  }
+  /// Get vector that holds the escape particles. NOT USED
   vector<vector<double> > GetEscapeVector() {
     return EscapeVector;
-  }  ///< get vector that holds the escape particles.
+  }
+  /**
+   * @short Set lower time boundary at which the particle iteration is started
+   *
+   * @param TMIN : lower time boundary [yr]
+   */
   void SetTmin(double TMIN) {
     TminExternal = TMIN;
-  }  ///< Constanty set minimal time of injected particles
+  }
+  /// @overload
   void SetBField(double BEXT) {
     BVector.clear();
     BConstant = BEXT;
     SetMembers(TminInternal);
-  }  ///< Constanty set B-Field value
+  }
+  /// @overload
   void SetAmbientDensity(double NCONSTANT) {
     NVector.clear();
     NConstant = NCONSTANT;
     SetMembers(TminInternal);
-  }  ///< Constanty set value of ambient density
+  }
+  /// @overload
   void SetRadius(double r) {
     RVector.clear();
     RConstant = pc_to_cm*r;
     SetMembers(TminInternal);
-  }  ///< Constanty set value of source extension (pc)
+  }
+  /// @overload
   void SetExpansionVelocity(double v) {
     VVector.clear();
     VConstant = v;
     SetMembers(TminInternal);
-  }  ///< Constanty set value of source expansion speed (cm/s)
+  }
+  /**@short DEPRECATED. Set shape of the Electron spectrum cut-off.
+   *
+   * It is advised to use the Particles::SetCustomInjectionSpectrum
+   * which allows any used defined function
+   *
+   * @param CUTOFFFACTOR : cutoff factor of an exponential function
+   */
   void SetCutOffFactor(double CUTOFFFACTOR) {
     CutOffFactor = CUTOFFFACTOR;
-  }  ///< set shape of the Electron spectrum cut-off
+  }
+  /// DEPRECATED: Get shape of the Electron spectrum cut-off.
   double GetCutOffFactor() {
     return CutOffFactor;
-  }  ///< get shape of the Electron spectrum cut-off
+  }
+  /**
+   * @short Set safety margin on the upper boundary of the particle spectrum.
+   *
+   * Energy safety margin above the spectral
+   * cut-off. E.g. energyMarginFactor = 1.e-3 means
+   * that the upper boundary of the energy spectrum
+   * corresponds to the point where the has dropped
+   * to 1/1000 exponential
+   *
+   * @param ENERGYMARGINFACTOR : safety margin above the cutoff
+   */
   void SetEnergyMarginFactor(double ENERGYMARGINFACTOR) {
     energyMarginFactor = ENERGYMARGINFACTOR;
-  }  ///< set safety margin on the upper boundary of the particle spectrum
+  }
+  /**
+   * @short Toggle (default: off) a sharp energy cut in the particle spectrum
+   * (position given by Emax)
+   *
+   * Doesn't do anything
+   *
+   * TODO: remove!!
+   */
   void ToggleSharpEnergyCut() {
     sharpEnergyCut = true;
-  }  ///< toggle (default: off) a sharp energy cut in the particle spectrum
-     ///(position given by Emax)
+  }
+  /**
+   * @short Untoggle (default: off) a sharp energy cut in the particle spectrum
+   * (position given by Emax)
+   *
+   * Doesn't do anything
+   *
+   * TODO: remove!!
+   */
   void UnToggleSharpEnergyCut() {
     sharpEnergyCut = false;
-  }  ///< untoggle a sharp energy cut in the particle spectrum (position given
-     ///by Emax)
+  }
+  /**
+   * @short Set minimal time from where to start the iteration (default: 1yr).
+   *
+   * @param TMININTERNAL This is the internal minimal time for which all
+   * lookups (B,N,R,V etc) are filled.
+   * If no lookups have been provided (constant losses etc), it is set to 0.
+   * The default value is 1 yr.
+   *
+   * Sets private attribute Particles::TminInternal
+   */
   void SetTminInternal(double TMININTERNAL) {
     TminInternal = TMININTERNAL;
-  }  ///< set minimal time from where to start the iteration (default: 1yr).
+  }
+  /**
+   * @short Get minimal time from where to start the iteration (default: 1yr).
+   *
+   * See Particles::SetTminInternal
+   *
+   * @return Particles::TminInternal
+   */
   double GetTminInternal() {
     return TminInternal;
-  }  ///< set minimal time from where to start the iteration (default: 1yr).
+  }
+  /**
+   * @short Return vector with the energy trajectory of the particle
+   * with maximum energy as vector of tuples (time, energy)
+   *
+   * @return vector with the energy trajectory of the particle
+   * as vector of tuples (time [s], energy[erg])
+   */
   vector<vector<double> > GetEnergyTrajectoryVector() { 
     vector< vector<double> > v;
     v = fUtils-> VectorAxisPow10(vETrajectory,0);
     v = fUtils-> VectorAxisPow10(v,1);
     return v; }
+  /**
+   * @short Return a particle SED E vs E^2dN/dE (TeV vs erg)
+   *
+   * @return vector of 2D tuples (E, E^2dN/dE) in units [TeV] and [erg]
+   */
   vector<vector<double> > GetParticleSED();
+  /**
+   * @short Return the 2D grid on which solving takes place (energy and time)
+   *
+   * @return Particles::grid
+   */
   vector<vector<double> > GetGrid(){return grid;}
+  /**
+   * @short Return total energy in particles between \a E1 [erg] and
+   * \a E2 [erg].
+   *
+   * @param E1 low energy bound for the integration (in erg)
+   * @param E2 high energy bound for the integration (in erg)
+   * @return Energy content in the interval in erg
+   */
   double GetParticleEnergyContent(double E1=0., double E2=0.);
-
+  /// @overload
   void SetLuminosity(double LUMConstant) {
     LumVector.clear();
     LumConstant = LUMConstant;
   }
+  /// DEPRECATED. Set lookup for the evolution of the maximum energy with time.
   void SetEmax(vector<vector<double> > EMAXLOOKUP) {
     EmaxConstant = NAN;
     SetLookup(EMAXLOOKUP, "Emax");
   } 
+  /**
+   * @short Set Particles::eminint
+   *
+   * @param eminint : This is an internal parameter that is relevant to the grid-solver.
+   * Essentially, it is used to determine the starting time of the iteration.
+   * The starting time is then determined in a way that all particles that are
+   * injected before that time are cooled to an energy of maximal
+   * EminInternal after a time t=age.
+   */
   void SetCriticalMinEnergyForGridSolver(double eminint) {EminInternal=eminint;}
+  /**
+   * @short Set the memory of the GSL workspace when integrating.
+   *
+   * Options are:
+   *  - "light"
+   *  - "normal" (default)
+   *  - "heavy"
+   *
+   * @param mode : setting of the GSL workspace
+   */
   void SetIntegratorMemory(string mode);
+  /// Set interpolation method. See Utils::SetInterpolationMethod
   void SetInterpolationMethod(string intermeth)
     {fUtils->SetInterpolationMethod(intermeth);}
+  /**
+   * @short Set a custom injection spectrum or escape time variable with time
+   * This can substitute the the SetLuminosity functions
+   *
+   * Input is a 2D vector with 3 columns: ((..,..,..),(..,..,..),...)
+   *
+   *  - mode 0 = custom injection spectrum:
+   *              - first column holds time in yrs,
+   *              - second energy in erg,
+   *              - third holds differential rate in erg^-1 s^-1.
+   *             If this is specified, otherwise defined spectral parameters
+   *             like luminosity lookups and specified spectral index will be ignored.
+   *             NOTE: you still have to specify emax (either via lookup or constant value).
+   *  - mode 1 = time and energy dependent escape time:
+   *              - first column holds time in yrs,
+   *              - second energy in erg,
+   *              - third holds escape time in seconds
+   *
+   * @param vCustom : 2D vector with 3 colums.
+   * @param mode : 0 or 1 , type of vector passed
+   */
   void SetCustomTimeEnergyLookup(vector< vector<double> > vCustom, int mode);
+  /**
+   * @short Set a custom injection spectrum.
+   *
+   * Input is a 2D vector with 2 columns: ((..,..),(..,..),...)
+   *
+   *  - mode = 0 -> custom injection spectrum lookup:
+   *                  - first column holds energy in erg.
+   *                  - second column holds differential rate in
+   *                    erg^-1 s^-1. If this is specified, otherwise defined spectral parameters
+   *                    like luminosity lookups and specified spectral index will be ignored.
+   *                    NOTE: you still have to specify emax (either via lookup or constant value).
+   *  - mode = 1 -> energy dependent particle escape time lookup:
+   *                 - first column holds energy in erg.
+   *                 - second column holds particle escape time in seconds
+   *
+   * @param vCustom : 2D vector with 2 columns.
+   * @param mode : 0 or 1 , type of vector passed
+   */
   void SetCustomEnergylookup(vector< vector<double> > vCustom,int mode);
 
   /* methods to set custom source injection spectra */
+  /**
+   * @short Custom injection spectrum, not varying with time
+   *
+   * See Particles::SetCustomEnergylookup
+   * Will clear LumVector
+   *
+   * @param vSpectrum : vector of 2D tuples as Energy [erg] dN/dE [erg^-1 s-1]
+   */
   void SetCustomInjectionSpectrum(vector< vector<double> > vSpectrum) {
     CustomInjectionSpectrumTimeEvolution = NULL;
     LumConstant = NAN;
     fUtils->Clear2DVector(LumVector);
-    SetCustomEnergylookup(vSpectrum,0);} ///< custom injection spectrum
-
+    SetCustomEnergylookup(vSpectrum,0);}
+  /**
+   * @short Custom injection spectrum varying over time
+   *
+   * See Particles::SetCustomTimeEnergyLookup
+   *
+   * @param vCustomSpectrum : vector of 3D tuples as Time [yr], Energy [erg], dN/dE [erg^-1 s-1]
+   */
   void SetCustomInjectionSpectrumTimeEvolution(vector< vector<double> > vCustomSpectrum) {
     CustomInjectionSpectrum = NULL;
-    SetCustomTimeEnergyLookup(vCustomSpectrum,0);}///< custom injection spectrum, changing over time
-
+    SetCustomTimeEnergyLookup(vCustomSpectrum,0);}
+  /**
+   * @short Custom injection spectrum, changing over time, input numpy-style meshgrid
+   *
+   * To be used with the python GAPPA functionality
+   *
+   * @param t : vector of times [yr]
+   * @param e : vector of particle energies [erg]
+   * @param mesh : numpy-style meshgrid as d^2N/(dEdt) evaluated at \a t and \a e.
+   *               See numpy.meshgrid
+   */
   void SetCustomInjectionSpectrumTimeEvolution(vector<double> t, vector<double> e, 
                                                 vector< vector<double> > mesh) {
     CustomInjectionSpectrum = NULL;
     vector< vector<double> > vCustomSpectrum = fUtils->MeshgridToTwoDVector(t,e,mesh);
-    SetCustomTimeEnergyLookup(vCustomSpectrum,0);}///< custom injection spectrum, changing over time, input numpy-style meshgrid
+    SetCustomTimeEnergyLookup(vCustomSpectrum,0);}
  
   /* methods to set particle escape */
+  /**
+   * @short Set the constant time scale of particle escape
+   *
+   * @param EscapeTime in yrs
+   */
   void SetConstantEscapeTime(double EscapeTime) {
     if(EscapeTime>0.) ESCTIME = true;
     escapeTimeLookupTdep = NULL;
     escapeTimeLookupEdep = NULL;
     EscapeTimeEnergyTimeEvolution = NULL;
     escapeTimeConstant = EscapeTime;
-  }  ///< set the time scale of particle escape
-
+  }
+  /**
+   * @short Set time dependent escape time for the particles
+   *
+   * @param vEsc : vector of 2D tuples (time, escape time) both as years
+   */
   void SetTimeDependentEscapeTime(vector< vector<double> > vEsc) {
     ESCTIME = true;
     escapeTimeConstant = NAN;
     escapeTimeLookupEdep = NULL;
     EscapeTimeEnergyTimeEvolution = NULL;
-    SetLookup(vEsc, "EscapeTimeTdep");} ///< Set escape time evolution
-
+    SetLookup(vEsc, "EscapeTimeTdep");}
+  /**
+   * @short Set energy-dependent escape time, but constant in time
+   *
+   * @param ESCTIMELOOKUP : vector of 2D tuples (energy, escape time) in units
+   * of (erg, yr)
+   */
   void SetEnergyDependentEscapeTime(vector<vector<double> > ESCTIMELOOKUP) {
     ESCTIME = true;
     escapeTimeConstant = NAN;
     escapeTimeLookupTdep = NULL;
     EscapeTimeEnergyTimeEvolution = NULL;
     SetCustomEnergylookup(ESCTIMELOOKUP, 1);
-  } ///< set energy-dependent escape time, constant 
-
+  }
+  /**
+   * @short set energy-dependent escape time, dynamic with time
+   *
+   * @param vEsc : vector of 3D tuples with (time, energy, escape time)
+   *               in units of (yr, erg, yr)
+   */
   void SetTimeAndEnergyDependentEscapeTime(vector< vector<double> > vEsc) {
     ESCTIME = true;
     escapeTimeConstant = NAN;
     escapeTimeLookupEdep = NULL;
     escapeTimeLookupTdep = NULL;
-    SetCustomTimeEnergyLookup(vEsc,1);}///< set energy-dependent escape time, dynamic
-
+    SetCustomTimeEnergyLookup(vEsc,1);}
+  /**
+   * @short Set energy-dependent escape time, dynamic. input numpy-style meshgrid.
+   *
+   * @param t : vector of times in years
+   * @param e : vectors of energies in erg
+   * @param mesh : numpy-style meshgrid as escape-time evaluated at \a t and \a e.
+   *               See numpy.meshgrid
+   */
   void SetTimeAndEnergyDependentEscapeTime(vector<double> t, vector<double> e, 
                                                 vector< vector<double> > mesh) {
     ESCTIME = true;
@@ -611,9 +967,17 @@ struct timespec time0, time1, time2, time3;
     escapeTimeLookupEdep = NULL;
     escapeTimeLookupTdep = NULL;
     vector< vector<double> > vEsc = fUtils->MeshgridToTwoDVector(t,e,mesh);
-    SetCustomTimeEnergyLookup(vEsc,1);}///< set energy-dependent escape time, dynamic. input numpy-style meshgrid.
+    SetCustomTimeEnergyLookup(vEsc,1);}
 
 /*  Radiation *GetSSCEquilibrium(Radiation *fr,double t, double tolerance=1e-2);*/
+  /**
+   * @short Set the solver method for the time evolution.
+   *
+   * @param method : type of solver
+   *                   - 0 grid solver
+   *                   - 1 semianalytic with const. losses,
+   *                   - 2 semianalytic with no losses.
+   */
   void SetSolverMethod(int method);
   void ToggleQuietMode() { QUIETMODE = QUIETMODE == true ? false : true; fRadiation->ToggleQuietMode();}  ///< toggle quiet mode on or off ( if on, no progress printout on the console)
   bool GetQuietMode() {return QUIETMODE;}
@@ -700,10 +1064,11 @@ struct timespec time0, time1, time2, time3;
     cout<< "SetAmbientDensityLookup: DEPRECATED! USE Particles::SetAmbientDensity(<vector<vector<double>>v) instead!"<<endl;
     SetAmbientDensity(NLOOKUP);
   }  ///< DEPRECATED
+  /// DEPRECATED: Set the luminosity evolution lookup
   void SetLuminosityLookup(vector<vector<double> > LUMLOOKUP) {
     LumConstant = NAN;
     SetLookup(LUMLOOKUP, "Luminosity");
-  }  ///< DEPRECATED
+  }
   void SetBFieldLookup(vector<vector<double> > BFIELDLOOKUP) {
     cout<< "SetBFieldLookup: DEPRECATED! USE Particles::SetBField(<vector<vector<double>>v) instead!"<<endl;
     SetBField(BFIELDLOOKUP);

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -577,7 +577,7 @@ struct timespec time0, time1, time2, time3;
   /**
    * @short Set the luminosity evolution lookup
    *
-   * @param vector of 2D tuples (time, luminosity) [yr] and [erg/s]
+   * @param LUMLOOKUP : vector of 2D tuples (time, luminosity) [yr] and [erg/s]
    */
   void SetLuminosity(vector<vector<double> > LUMLOOKUP) {
     LumConstant = NAN;
@@ -1174,7 +1174,7 @@ struct timespec time0, time1, time2, time3;
     return fRadiation->GetICLossLookup(i);
   };
   /**
-   * @short Returns the energy density of the \i target photon field
+   * @short Returns the energy density of the \a i target photon field
    *
    * @param i : index of photon field.
    *

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -161,6 +161,7 @@ struct timespec time0, time1, time2, time3;
 
   double synchl,icl,adl,bremsl,ionization,ppcol; ///< loss rates for synchrotron, IC, adiabatic exp.,
                                                  /// bremsstrahlug and ionizarion and pp collision for protons
+  bool IONIZATION;  ///< Boolean to decide if to compute or not the ionization losses.
 
   bool logarithmicCRLumLookupTimeBins;  ///< boolean indicating that time steps
                                         ///in CRLumLookup are logarithmic. In
@@ -338,8 +339,15 @@ struct timespec time0, time1, time2, time3;
                                                int bins = 100, bool ICRESET=false) {
     ComputeGridInTimeInterval(T1,T2,"electrons",bins,ICRESET);}
   void CalculateElectronSpectrumInTimeInterval(int bins = 100) {CalculateParticleSpectrum("electrons",bins);}
-  void SetType(string type);
+  void SetType(string type);  ///< Set the particle type ("protons" or "electrons")
   double EnergyLossRate(double E);  ///< total energy loss rate of particles
+  void SetIonization() {
+	  IONIZATION = true;
+  }  ///< Set the calculation of the ionization. This is because normally we consider fully ionized plasma
+     /// if you really want to compute ionization losses, call this function
+  void UnsetIonization() {
+	  IONIZATION = false;
+  }  ///< Unset accounting for ionization losses.
   void SetAge(double age) {
     Age = age;
     SetMembers(Age);

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -10,22 +10,23 @@
 
 using namespace std;
 
-/**  @file Particles.C
- *   @author Joachim Hahn
- *   @short Class that calculates particle spectra
- *   This class allows for the time-dependent model of particle spectra,
- *   using as a center piece a numerical algorithm (a piece-wise linear
- *   advection scheme in energy space. Thus, in principle any time evolution of
- *   energy losses and particle injection can be assumed and the resulting
- * particle
- *   distribution can be calculated.
- *   What this code cannot do is the simultaneous spatial evolution of
- * particles, e.g.
- *   energy dependent diffusion. Here, no assumptions on the spatial
- * distribution of
- *   particles is made whatsoever.
+/**
+ * @file Particles.C
+ *
+ * @author Joachim Hahn
+ *
+ * @short Class that calculates particle spectra
+ * This class allows for the time-dependent model of particle spectra,
+ * using as a center piece a numerical algorithm (a piece-wise linear
+ * advection scheme in energy space. Thus, in principle any time evolution of
+ * energy losses and particle injection can be assumed and the
+ * resulting particle distribution can be calculated.
+ * What this code cannot do is the simultaneous spatial evolution of
+ * particles, e.g. energy dependent diffusion.
+ * Here, no assumptions on the spatial
+ * distribution of particles is made whatsoever.
+ *
  */
-
 class Particles {
   typedef double (Particles::*fPointer)(double, void *);
 
@@ -38,163 +39,251 @@ struct timespec time0, time1, time2, time3;
  private:
   Utils *fUtils;
   Radiation *fRadiation;
-  int Type;  ///< integer indicating particle type. supported: 0-electrons and
-             ///1-protons
-  int METHOD; /// calculation method. This is determined automatically, but can
-              /// be force set via SetSolverMethod(). However, if an inappropriate
-              /// method is chosen manually, the result might be wrong or
-              /// the program might crash.
-              /// 0: grid solver,
-              /// 1: semi-analytical method in the presence of constant losses
-              /// 2: no losses (simply adds up according to luminosity)
-  bool FASTMODE; /// grid solver: sacrifice accuracy for speed. -> true: disables slope limiters. default: false
-
-  bool ESCTIME;/// boolean that indicates whether an escape time has been set. This will be automatically set to 'true' if any method for escape is used. default: false
-  double theta;           ///< CR acceleration efficiency
-  double SpectralIndex;   ///< spectral index of injected particles
-  double SpectralIndex2;  ///< low-energy spectral index for broken power law
-                          ///injection spectrum
-  double SpectralIndexConstant;   ///< spectral index of injected particles
-                                  ///manually set to a constant value
-  double SpectralIndex2Constant;  ///< low-energy spectral index for broken
-                                  ///power law injection spectrum manually set
-                                  ///to a constant value
-  double Kep;                     ///< electron-to-proton _number_ ratio
-  double Tmin;  ///< optimised minimal time from which to start particle
-                ///injection (given by the 'maximal' starting time that doesn't
-                ///change results)
-  double TminInternal;  ///< internal minimal time for which all lookups
-                        ///(B,N,R,V etc) are filled. If no lookups are provided
-                        ///(constant losses etc), it is set to 0.
-  double TmaxInternal;  ///< Same as TminInternal but here it is the maximal
-                        ///time
-  double TActual;  ///< Actual time of iteration time step
-  double TIterationStart; ///< start time when using grid solver
-  double EminInternal;  ///< internal parameter that is relevant to the grid-
-                        /// solver. Essentially, it is used to determine the
-                        /// starting time of the iteration. The starting time
-                        /// is then determined in a way that all particles that
-                        /// are injected before that time are cooled to an
-                        /// energy of maximal EminInternal after a time t=age.
-  double MinELookup;    ///< Lower energy bound of custom injection lookup.
-                        ///  If time evolution of custom spectrum is given, this
-                        ///  is reset at every T = Age step.
-  double MaxELookup;    ///< Upper energy bound of custom injection lookup.
-                        ///  If time evolution of custom spectrum is given, this
-                        ///  is reset at every T = Age step.
-  double TminLookup;    ///< Lower time bound of custom injection lookup.
-  double TmaxLookup;    ///< Higher time bound of custom injection lookup.
-  double BField;        ///< amplified B-field immediately dowmstream
-  double N;             ///< ambient density (only refers to protons. Assumes additional 10% of it as Helium)
-  double R;             ///< source extension (cm)
-  double V;             ///< source expansion velocity (cm/s)
-  double Lum;           ///< energy injection rate at a given time
-  double Emin;  ///< internally and dynamically determined lower energy boundary
-                ///within which the particle spectrum is calculated
-  bool EminConstantForNormalisationOnly;  ///< flag that, if set to 'true'
-                                          ///indicates that emin will only be
-                                          ///used in the calculation of the
-                                          ///particle norm, but not the spectral
-                                          ///range.
-  double Emax;  ///< internally and dynamically determined upper energy boundary
-                ///within which the particle spectrum is calculated
-  double EminConstant;  ///< Constantly set lower energy boundary within which
-                        ///the particle spectrum is calculated (optional)
-  double EmaxConstant;  ///< Constantly set upper energy boundary within which
-                        ///the particle spectrum is calculated (optional)
-  double TminExternal;  ///< Constantly set lower time boundary at which the
-                        ///particle iteration is started
-  double BConstant;     ///< Constantly set constant B-Field
-  double NConstant;     ///< Constantly set constant ambient density
-  int iclosslookupbins; ///< bins of the IC-Loss lookup
-  double LumConstant;   ///< Constantly set source luminosity
-  double RConstant;     ///< Constantly set source extension
-  double VConstant;     ///< Constantly set source expansion speed
-  double eMax;          ///< maximum energy of particles the shock can contain
-  double eBreak;  ///< break energy for a broken power-law particle injection
-                  ///spectrum
-  double CustomInjectionNorm;///< energy content in injection spectrum before normalisation
-  double eBreakConstant;  ///< break energy for a broken power-law particle
-                          ///injection spectrum manually set to a constant value
-  double energyMarginFactor;  ///< energy safety margin above the spectral
-                              ///cut-off. E.g. energyMarginFactor = 1.e-3 means
-                              ///that the upper boundary of the energy spectrum
-                              ///corresponds to the point where the has dropped
-                              ///to 1/1000 exponential
-  double energyMargin;  ///< this is the dynamically determined margin that
-                        ///results from energyMarginFactor and CutOffFactor. It
-                        ///determines the upper energy boundary of the particle
-                        ///spectrum as upper_boundary = emax*energyMargin.
-  double CutOffFactor;  ///< factor determining the strength of the exponential
-                        ///cut-off in the particle injection spectrum:
-                        ///f~exp[-(e/ecut)^CutOffFactor]
-  bool sharpEnergyCut;  ///< toggle a sharp cut-off at emax
-  double Age;           ///< source age
-  double eBreakS2;      ///< constant used in 'SourceSpectrum'. Used for speed
-                        ///optimisation
-  double eBreak2mS2;    ///< constant used in 'SourceSpectrum'. Used for speed
-                        ///optimisation
-  double eBreakS;       ///< constant used in 'SourceSpectrum'. Used for speed
-                        ///optimisation
-  double eBreak2mS;     ///< constant used in 'SourceSpectrum'. Used for speed
-                        ///optimisation
-  double emin2mS2;      ///< constant used in 'SourceSpectrum'. Used for speed
-                        ///optimisation
-  double emin2mS;       ///< constant used in 'SourceSpectrum'. Used for speed
-                        ///optimisation
-  double emineBreak2mS2;  ///< constant used in 'SourceSpectrum'. Used for speed
-                          ///optimisation
-  double eBreak2mSInd2;   ///< constant used in 'SourceSpectrum'. Used for speed
-                          ///optimisation
-  double emin2mSInd2;     ///< constant used in 'SourceSpectrum'. Used for speed
-                          ///optimisation
-  double emineBreak2mSInd2;  ///< constant used in 'SourceSpectrum'. Used for
-                             ///speed optimisation
-  double fS;           ///< constant used in 'SourceSpectrum'. Used for speed
-                       ///optimisation
-  double fS2;          ///< constant used in 'SourceSpectrum'. Used for speed
-                       ///optimisation
-  double bremsl_epf;   ///< constant used in 'EnergyLossRate'. Used for speed
-                       ///optimisation
-  double bremsl_eef;   ///< constant used in 'EnergyLossRate'. Used for speed
-                       ///optimisation
-
-  double synchl,icl,adl,bremsl,ionization,ppcol; ///< loss rates for synchrotron, IC, adiabatic exp.,
-                                                 /// bremsstrahlug and ionizarion and pp collision for protons
-  bool IONIZATION;  ///< Boolean to decide if to compute or not the ionization losses.
-
-  bool logarithmicCRLumLookupTimeBins;  ///< boolean indicating that time steps
-                                        ///in CRLumLookup are logarithmic. In
-                                        ///this case, the precise entry in the
-                                        ///Lookup up for a given time can be
-                                        ///calculated rather than iterated
-  bool linearCRLumLookupTimeBins;  ///< boolean indicating that time steps in
-                                   ///CRLumLookup are linear. In this case, the
-                                   ///precise entry in the Lookup up for a given
-                                   ///time can be calculated rather than
-                                   ///iterated
-  double CRLumLookupTimeMin;  ///< starting time (earliest entry) of CRLumLookup
-  double CRLumLookupTimeMax;  ///< ending time (last entry) of CRLumLookup
-  double logCRLumLookupTimeMin;         ///< log10 of CRLumLookupTimeMin (speed
-                                        ///optimisation)
-  double logCRLumLookupTimeMax;         ///< log10 of CRLumLookupTimeMax (speed
-                                        ///optimisation)
-  unsigned int CRLumLookupSize;         ///< entries of CRLumLookup
-  double CRLumLookupdeltat;             ///< time bin size in CRLumLookup
-  vector<vector<double> > CRLumLookup;  ///< 2D-vector containing quantities
-                                        ///needed to calculate particle spectra.
-                                        ///Each line comprises the quantities at
-                                        ///a gives time. This allows for
-                                        ///time-dependent modeling. Format:
-                                        ///time(yrs) - e_dot( erg/s, luminosity
-                                        ///of source put into acc.particles -
-                                        ///radius (cm) - speed (cm/s) -
-                                        ///ambient_density (cm^-3) -
-                                        ///ambient_density2 (cm^-3) - magn.Field
-                                        ///(G) - max. energy of injected protons
-                                        ///(erg) - max. energy of injected
-                                        ///electrons (erg) - escape time
-
+  /**
+   * @short Integer for particle type. Supported values:
+   *   - 0 - electrons
+   *   - 1 - protons
+   */
+  int Type;
+  /**
+   * @short Calculation method. This is determined automatically, but can
+   * be force set via SetSolverMethod(). However, if an inappropriate
+   * method is chosen manually, the result might be wrong or the program
+   * might crash. Options:
+   *   - 0: grid solver,
+   *   - 1: semi-analytical method in the presence of constant losses
+   *   - 2: no losses (simply adds up according to luminosity)
+   */
+  int METHOD;
+  /**
+   * Grid solver option: sacrifice accuracy for speed.
+   * If true: disables slope limiters.
+   * Default: false
+   */
+  bool FASTMODE;
+  /**
+   * Boolean that indicates whether an escape time has been set.
+   * This will be automatically set to 'true' if any method for escape is used.
+   * Default: false
+   */
+  bool ESCTIME;
+  /// NOT IMPLEMENTED. CR acceleration efficiency.
+  double theta;
+  /// Spectral index of injected particles
+  double SpectralIndex;
+  /// Low-energy spectral index for broken power law injection spectrum
+  double SpectralIndex2;
+  ///< Spectral index of injected particles manually set to a constant value
+  double SpectralIndexConstant;
+  /**
+   * Low-energy spectral index for broken
+   * power law injection spectrum manually set
+   * to a constant value
+   */
+  double SpectralIndex2Constant;
+  /// NOT USED. Electron-to-proton _number_ ratio
+  double Kep;
+  /**
+   * Optimised minimal time from which to start particle injection
+   * (given by the 'maximal' starting time that doesn't change results)
+   */
+  double Tmin;
+  /**
+   * Internal minimal time for which all lookups
+   * (B,N,R,V etc) are filled. If no lookups are provided
+   * (constant losses etc), it is set to 0.
+   */
+  double TminInternal;
+  /// Same as TminInternal but here it is the maximal time
+  double TmaxInternal;
+  /// Actual time of iteration time step
+  double TActual;
+  /// Start time when using grid solver
+  double TIterationStart;
+  /**
+   * Internal parameter that is relevant to the grid-solver.
+   * Essentially, it is used to determine the
+   * starting time of the iteration. The starting time
+   * is then determined in a way that all particles that
+   * are injected before that time are cooled to an
+   * energy of maximal EminInternal after a time t=age.
+   */
+  double EminInternal;
+  /**
+   * Lower energy bound of custom injection lookup.
+   * If time evolution of custom spectrum is given, this
+   * is reset at every T = Age step.
+   */
+  double MinELookup;
+  /**
+   * Upper energy bound of custom injection lookup.
+   * If time evolution of custom spectrum is given, this
+   * is reset at every T = Age step.
+   */
+  double MaxELookup;
+  /// Lower time bound of custom injection lookup.
+  double TminLookup;
+  /// Higher time bound of custom injection lookup.
+  double TmaxLookup;
+  /// Amplified B-field immediately dowmstream
+  double BField;
+  /// Ambient density (only refers to protons. Assumes additional 10% of it as Helium)
+  double N;
+  /// Source extension (cm)
+  double R;
+  /// Source expansion velocity (cm/s)
+  double V;
+  /// Energy injection rate at a given time
+  double Lum;
+  /**
+   * Internally and dynamically determined lower energy boundary
+   * within which the particle spectrum is calculated
+   */
+  double Emin;
+  /**
+   * Flag that, if set to 'true' indicates that emin will only be
+   * used in the calculation of the particle norm, but not the spectral range.
+   */
+  bool EminConstantForNormalisationOnly;
+  /**
+   * Internally and dynamically determined upper energy boundary
+   * within which the particle spectrum is calculated
+   */
+  double Emax;
+  /**
+   * Constantly set lower energy boundary within which
+   * the particle spectrum is calculated (optional)
+   */
+  double EminConstant;
+  /**
+   * Constantly set upper energy boundary within which
+   * the particle spectrum is calculated (optional)
+   */
+  double EmaxConstant;
+  /**
+   * Constantly set lower time boundary at which the
+   * particle iteration is started
+   */
+  double TminExternal;
+  /// Constantly set constant B-Field
+  double BConstant;
+  /// Constantly set constant ambient density
+  double NConstant;
+  /// Bins of the IC-Loss lookup
+  int iclosslookupbins;
+  /// Constantly set source luminosity
+  double LumConstant;
+  /// Constantly set source extension
+  double RConstant;
+  /// Constantly set source expansion speed
+  double VConstant;
+  /// Maximum energy of particles the shock can contain
+  double eMax;
+  /// Break energy for a broken power-law particle injection spectrum
+  double eBreak;
+  /// Energy content in injection spectrum before normalisation
+  double CustomInjectionNorm;
+  /**
+   * Break energy for a broken power-law particle injection
+   * spectrum manually set to a constant value
+   */
+  double eBreakConstant;
+  /**
+   * Energy safety margin above the spectral cut-off.
+   * E.g. energyMarginFactor = 1.e-3 means that the upper boundary of
+   * the energy spectrum corresponds to the point where the has dropped
+   * to 1/1000 exponential
+   */
+  double energyMarginFactor;
+  /**
+   * this is the dynamically determined margin that
+   * results from energyMarginFactor and CutOffFactor. It
+   * determines the upper energy boundary of the particle
+   * spectrum as upper_boundary = emax*energyMargin.
+   */
+  double energyMargin;
+  /**
+   * Factor determining the strength of the exponential
+   * cut-off in the particle injection spectrum:
+   * f~exp[-(e/ecut)^CutOffFactor]
+   */
+  double CutOffFactor;
+  /// Toggle a sharp cut-off at emax
+  bool sharpEnergyCut;
+  /// Source Age
+  double Age;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double eBreakS2;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double eBreak2mS2;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double eBreakS;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double eBreak2mS;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double emin2mS2;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double emin2mS;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double emineBreak2mS2;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double eBreak2mSInd2;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double emin2mSInd2;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double emineBreak2mSInd2;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double fS;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double fS2;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double bremsl_epf;
+  /// constant used in 'SourceSpectrum'. Used for speed optimisation
+  double bremsl_eef;
+  /**
+   * loss rates for synchrotron, IC, adiabatic exp.,
+   * bremsstrahlug and ionization and pp collision for protons
+   */
+  double synchl, icl, adl, bremsl, ionization, ppcol;
+  /// Boolean to decide if to compute or not the ionization losses.
+  bool IONIZATION;
+  /**
+   * NOT USED. boolean indicating that time steps in CRLumLookup are logarithmic.
+   * In this case, the precise entry in the Lookup up for a given time
+   * can be calculated rather than iterated
+   */
+  bool logarithmicCRLumLookupTimeBins;
+  /**
+   * NOT USED. Boolean indicating that time steps in CRLumLookup are linear.
+   * In this case, the precise entry in the Lookup up for a given
+   * time can be calculated rather than iterated
+   */
+  bool linearCRLumLookupTimeBins;
+  /// NOT USED. Starting time (earliest entry) of CRLumLookup
+  double CRLumLookupTimeMin;
+  /// NOT USED. ending time (last entry) of CRLumLookup
+  double CRLumLookupTimeMax;
+  /// NOT USED. log10 of CRLumLookupTimeMin (speed optimisation)
+  double logCRLumLookupTimeMin;
+  /// NOT USED. log10 of CRLumLookupTimeMax (speed optimisation)
+  double logCRLumLookupTimeMax;
+  /// NOT USED. entries of CRLumLookup
+  unsigned int CRLumLookupSize;
+  /// time bin size in CRLumLookup
+  double CRLumLookupdeltat;
+  /**
+   * NOT USED. 2D-vector containing quantities
+   * needed to calculate particle spectra.
+   * Each line comprises the quantities at
+   * a gives time. This allows for time-dependent modeling.
+   * Format: time(yrs) - e_dot( erg/s, luminosity of source put into
+   * acc.particles - radius (cm) - speed (cm/s) - ambient_density (cm^-3) -
+   * ambient_density2 (cm^-3) - magn.Field(G) -
+   * max. energy of injected protons(erg) -
+   * max. energy of injected electrons (erg) - escape time
+   */
+  vector<vector<double> > CRLumLookup;
+  /// Definition of lookups
   vector<vector<double> > ICLossVector, LumVector, NVector, BVector, eMaxVector,
       escapeTimeVectorEdep, escapeTimeVectorTdep, RVector, VVector,tempspec,
       CustomInjectionSpectrumTimeEvolutionVector,
@@ -207,99 +296,112 @@ struct timespec time0, time1, time2, time3;
   gsl_interp_accel *accIC, *accLum, *accN, *accBField, *acceMax, *accescapeTimeEdep,
       *accescapeTimeTdep,*accR, *accV, *accTr, *accTrInv,*accCustInj,
       *taccsp,*eaccsp,*taccesc,*eaccesc;
-  double SourceSpectrum(double e);  ///< particle injection spectrum
-  double EscapeTime(double e, double t);  ///< particle escape time spectrum
-  vector<double> energyAxis;        ///< energy axis for numerical integrator
-  vector<vector<double> > grid;     ///< 2D grid on which solving takes place
-  vector<vector<double> > diffusegrid;  ///< 2D grid of the streaming particles
-  double ebins;                         ///< energy bins of grid (default: 100)
-  void DetermineTMin(double emin,
-                     double &tmin);  ///< determine the minimum time from where
-                                     ///to start the calculation. Electrons
-                                     ///before that time are injected as a
-                                     ///single 'blob'. This time is derived from
-                                     ///the requirement that the blob has slid
-                                     ///down to energies E<1GeV at t=Age.
+
+
+  /// Particle injection spectrum. Returns evaluation of spectrum at energy \a e
+  double SourceSpectrum(double e);
+  /// Particle escape time spectrum
+  double EscapeTime(double e, double t);
+  /// Energy axis for numerical integrator
+  vector<double> energyAxis;
+  /// 2D grid on which solving takes place
+  vector<vector<double> > grid;
+  /// NOT YET IMPLEMENTED. 2D grid of the streaming particles
+  vector<vector<double> > diffusegrid;
+  /// Energy bins of grid (default: 100)
+  double ebins;
+  /// Determine the minimum time from where to start the calculation.
+  void DetermineTMin(double emin, double &tmin);
+  /// Grid solver to calculate the final particle spectrum
   void PrepareAndRunNumericalSolver(vector<vector<double> > &particlespectrum,
                                     bool onlyprepare = false,
-                                    bool dontinitialise =
-                                        false);  ///< grid solver to calculate
-                                                 ///the final particle spectrum
+                                    bool dontinitialise = false);
+  /// Create an axis that attributes each bin with a real value
   void GetAxis(double min, double max, int steps, vector<double> &Axis,
-               bool logarithmic);  ///< create an axis that attributes each bin
-                                   ///with a real value (e.g. time axis, energy
-                                   ///axis).
-  void CreateGrid();  ///< create the 2D propagation grid out of 2 1D-vectors
+               bool logarithmic);
+  /// Create the 2D propagation grid out of 2 1D-vectors
+  void CreateGrid();
+  /// set initial condition (a.k.a. set the first time spectrum in the grid)
   void SetInitialCondition(vector<double> EnergyAxis,
-                           double startTime);  ///< set initial condition
-                                               ///(a.k.a. set the first time
-                                               ///spectrum in the grid)
+                           double startTime);
+ /**
+  * Iterate through the time-energy grid. Implemented is a piece-wise
+  * linear advection algorithm, optionally with the 'Superbee'-Slope
+  * limiter
+  */
   void ComputeGrid(vector<double> EnergyAxis,
                    double startTime, double Age, double minTimeBin =
-                       1. * yr_to_sec);  ///< Iterate through the time-energy
-                                         ///grid. Implemented is a piece-wise
-                                         ///linear advection algorithm,
-                                         ///optionally with the 'Superbee'-Slope
-                                         ///limiter
+                       1. * yr_to_sec);
   //void FillEnergyTrajectoryLookup();  ///NOT DEFINED
   //double CalcSpecSemiAnalyticConstELossIntegrand(double *x, double *par);  ///NOT DEFINED
+  /// Semi-analytical solution, only for time-independent energy losses.
   void CalcSpecSemiAnalyticConstELoss();
+  /// This calculates the particle spectrum without losses.
   void CalcSpecSemiAnalyticNoELoss();
-  double MaxMod(double a,
-                double b);  ///< Mod function required for slope delimiters
-  double MinMod(double a,
-                double b);  ///< Mod function required for slope delimiters
-  double GetSuperBeeSlope(int i, double deltaX,int i0);  ///< slope for
-                                                           ///superbee slope
-                                                           ///limiter method
-  double GetMinModSlope(int i, double deltaX,int i0);  ///< slope for the
-                                                         ///minmod slope limiter
-                                                         ///method
-  double LaxWendroffSlope(int i, double deltaX, int i0);  ///< slope for the
-                                                          // Lax-Wendroff slope limiter
-  vector<vector<double> > ParticleSpectrum;  ///< vector containing the final
-                                             ///source particle spectrum (i.e.
-                                             ///at time=Age)
-  vector<vector<double> > EscapeVector;      ///< vector containing escape delta
-                                         ///functions for later diffusion (done
-                                         ///by the 'Diffusion' class)
-  double DetermineEmax(double tmin);  ///< maximum allowed particle energy over
-                                      ///the course of the source's history
-  bool DEBUG;                         ///< Debug flag
-  double adLossCoeff;                 ///< coefficient for adiabatic losses
-  double escapeTime;                  ///< particle escape time
-  double escapeTimeConstant;  ///< particle escape time, Constantly set to a
-                              ///single value
-  double EnergyAxisLowerBoundary;  ///< might be superfluous (compare to
-                                   ///EminConstant)
-  double EnergyAxisUpperBoundary;  ///< might be superfluous (compare to
-                                   ///EmaxConstant)
-  bool QUIETMODE;  ///< Quietmode boolean: no output text at all if set to true
-                   ///. Default is false.
+  /// Mod function required for slope delimiters
+  double MaxMod(double a, double b);
+  /// Mod function required for slope delimiters
+  double MinMod(double a, double b);
+  /// Slope for superbee slope limiter method
+  double GetSuperBeeSlope(int i, double deltaX, int i0);
+  /// Slope for MinMod slope limiter method
+  double GetMinModSlope(int i, double deltaX, int i0);
+  /// slope for the Lax-Wendroff slope limiter
+  double LaxWendroffSlope(int i, double deltaX, int i0);
+  /// Vector containing the final source particle spectrum (i.e. at time Age)
+  vector<vector<double> > ParticleSpectrum;
+  /**
+   * NOT YET IMPLEMENTED. vector containing escape delta functions
+   * for later diffusion (done by the 'Diffusion' class)
+   */
+  vector<vector<double> > EscapeVector;
+  /// Maximum allowed particle energy over the course of the source's history
+  double DetermineEmax(double tmin);
+  /// Debug flag
+  bool DEBUG;
+  /// Coefficient for adiabatic losses
+  double adLossCoeff;
+  /// Particle escape time
+  double escapeTime;
+  /// Particle escape time, Constantly set to a single value
+  double escapeTimeConstant;
+  /// might be superfluous (compare to EminConstant)
+  double EnergyAxisLowerBoundary;
+  /// might be superfluous (compare to EmaxConstant)
+  double EnergyAxisUpperBoundary;
+  /// Quietmode boolean: no output text at all if set to true. Defualt: false
+  bool QUIETMODE;
+  /*
   // double Polynomial(double x, vector<double>);  ///< polynomial function, used
-                                                ///for deriving systematic
-                                                ///errors due to numerical
-                                                ///wiggling. NOT DEFINED
-  void CalculateConstants();  ///< speed hack where often used constants are
-                              ///calculated ahead of the grid solving
+                                                   ///for deriving systematic
+                                                   ///errors due to numerical
+                                                   ///wiggling. NOT DEFINED
+  */
+  /// Calculate constants ahead of grid solver. Speed hack
+  void CalculateConstants();
+  /// DEPRECATED? Power Law injection spectrum
   double PowerLawInjectionSpectrum(double e, double ecut,
-                                   double emax);  ///< power law injection
-                                                  ///spectrum. If eBreak and
-                                                  ///SpectralIndex2 are
-                                                  ///specified, returns a broken
-                                                  ///power law.
+                                   double emax);
   // double InverseLossRate(double *x, double *par);   ///NOT DEFINED
-  void SetLookup(vector<vector<double> > v, string LookupType);  ///<Sets lookup for evolution
+  /// Sets lookup for evolution
+  void SetLookup(vector<vector<double> > v, string LookupType);
+  /// Extend Lookup
   void ExtendLookup(vector<vector<double> > v, string LookupType);
+  /// Integrand of the time-integration of the semi-analytical solution.
   double SemiAnalyticConstELossIntegrand(double T, void *par);
+  /// See Particles::SourceSpectrum
   double SourceSpectrumWrapper(double E, void *par);
+  /// tolerance of the integrator
   double integratorTolerance;
+  /// Wrapper around gsl integration
   double Integrate(fPointer f, double *x, double emin, double emax,
                    double tolerance, int kronrodrule);
-  int gslmemory; ///< memory of the GSL workspace when integrating.
-                 /// Default = 5000
+  /// memory of the GSL workspace when integrating. Default = 5000
+  int gslmemory;
+  /// mode integration
   int kronrodrule;
-  vector<double> Constants;  ///< Auxiliary vector for speed-up
+  /// Auxiliary vector for speed-up
+  vector<double> Constants;
   vector<gsl_spline *> splines;
   vector<gsl_interp_accel *> accs;
   vector<double *> vals;
@@ -307,23 +409,20 @@ struct timespec time0, time1, time2, time3;
   vector<vector<vector<double> > > vs;
   void CalculateEnergyTrajectory(double TExt = 0.);
   void DetermineLookupTimeBoundaries();
+  /// wrapper function to calculate the grid only in a specified time interval dT = T2-T2 (yrs)
   void ComputeGridInTimeInterval(double T1, double T2, string type, int bins,
                                  bool ICRESET);
-                                              ///< wrapper function to calculate
-                                              /// the grid only in a specified
-                                              /// time interval dT = T2-T2 (yrs)
+  ///Returns either energy loss rate or cooling time
   vector< vector<double> > GetEnergyLossRateVector(vector<double> epoints,
                                                    string type, double age, 
-                                                        bool TIMESCALE); ///< Returns either
-                                                                         /// energy loss rate or
-                                                                         /// cooling time
+                                                        bool TIMESCALE);
+  /// Returns the injection spectrum:
   vector< vector<double> > GetInjectionSpectrumVector(vector<double> epoints,
                                                       double age, bool SED);
+  /// fill the lookup holding the particle spectrum {E(erg) - N(erg^-1)
   void CalculateParticleSpectrum(string type = "electrons", int bins = 100,
                                  bool onlyprepare = false,
-                                 bool dontinitialise = false); ///< fill the
-                                                               ///lookup that holds
-                                                               ///the particle spectrum.
+                                 bool dontinitialise = false);
  public:
   /// Default constructor
   Particles();
@@ -575,11 +674,13 @@ struct timespec time0, time1, time2, time3;
    *  @return loss rate in erg/s
    */
   double GetEnergyLossRate(double E, string type,double age=0.);
-  /** Return the cooling time scale at energy E [erg] and time age in [years]
+  /**
+   * @short Return the cooling time scale at energy E [erg] and time age in [years]
    *
    * @param E : energy of the particle in erg
    * @param type : type of loss process (see Particles::GetEnergyLossRate)
    * @param age : age of the system for calculation [yrs] (default = 0)
+   *
    * @return energy loss rate in erg/s
    */
   double GetCoolingTimeScale(double E, string type="sum", double age=0.) {
@@ -979,33 +1080,169 @@ struct timespec time0, time1, time2, time3;
    *                   - 2 semianalytic with no losses.
    */
   void SetSolverMethod(int method);
-  void ToggleQuietMode() { QUIETMODE = QUIETMODE == true ? false : true; fRadiation->ToggleQuietMode();}  ///< toggle quiet mode on or off ( if on, no progress printout on the console)
+  /// Toggle quiet mode on or off ( if on, no progress printout on the console)
+  void ToggleQuietMode() { QUIETMODE = QUIETMODE == true ? false : true; fRadiation->ToggleQuietMode();}
+  /// Return QIETMODE status
   bool GetQuietMode() {return QUIETMODE;}
-  void AddThermalTargetPhotons(double T, double edens, int steps=200);// wrapped from Radiation class. See Docu there.
-  void ResetWithThermalTargetPhotons(int i, double T, double edens, int steps=200);// wrapped from Radiation class. See Docu there.
-  void AddArbitraryTargetPhotons(vector<vector<double> > PhotonArray);// wrapped from Radiation class. See Docu there.
+  /**
+   * @short Add a Thermal photon field as target photon for IC cooling
+   *
+   * This assumes a grey body functional form, fully determined by Temperature
+   * and energy density of the field.
+   *
+   * @param T : temperature of the field [K]
+   * @param edens : energy density of the photon field [erg/cm^-3]
+   * @param steps : number of steps for the lookup
+   *
+   * Wrapped from Radiation::AddThermalTargetPhotons
+   */
+  void AddThermalTargetPhotons(double T, double edens, int steps=200);
+  /**
+   * @short Reset photon field \a i to be a thermal photon field
+   *
+   * @param i : index of photon field to substitute
+   * @param T : temperature of the field [K]
+   * @param edens : energy density of the photon field [erg/cm^-3]
+   * @param steps : number of steps for the lookup
+   *
+   * Wrapped from Radiation::ResetWithThermalTargetPhotons
+   */
+  void ResetWithThermalTargetPhotons(int i, double T, double edens, int steps=200);
+  /**
+   * @short Add an arbitrary shape for a photon field
+   *
+   * @param PhotonArray : vector of 2D tuples (energy, dN/dE)??? CHECK
+   *
+   * Wrapped from Radiation::AddArbitraryTargetPhotons
+   */
+  void AddArbitraryTargetPhotons(vector<vector<double> > PhotonArray);
+  /**
+   * @short Reset photon field \a i to be an arbitrary photon field
+   *
+   * @param i : index of photon field to substitute
+   * @param PhotonArray : vector of 2D tuples (energy, dN/dE)??? CHECK
+   *
+   * Wrapped from Radiation::ResetWithArbitraryTargetPhotons
+   */
   void ResetWithArbitraryTargetPhotons(int i,vector<vector<double> > PhotonArray);
-  void ImportTargetPhotonsFromFile(const char *phFile); // wrapped from Radiation class. See Docu there.
+  /**
+   * @short Import target field from a file
+   *
+   * @param phFile
+   *
+   * Wrapped from Radation::ImportTargetPhotonsFromFile
+   */
+  void ImportTargetPhotonsFromFile(const char *phFile);
+  /**
+   * @short Reset photon field \a i to be a photon field read from a file
+   *
+   * @param i : index of photon field that needs to be substituted
+   * @param phFile
+   */
   void ResetWithTargetPhotonsFromFile(int i,const char *phFile);
-  void AddSSCTargetPhotons(int steps=100); // wrapped from Radiation class. See Docu there. Radius in pc
+  /**
+   * @short Add the Synchrotron Self Compton field.
+   *
+   * @param steps : number of bins to sample the SSC field
+   *
+   * Wrapped from Radiation::AddSSCTargetPhotons
+   *
+   * NOTE: These functions are still a bit unstable for the Particles class
+   */
+  void AddSSCTargetPhotons(int steps=100);
+  /**
+   * @short Reset photon field \a i to be an arbitrary photon field
+   *
+   * @param i : photon field that needs to be substituted
+   * @param steps : number of bins to sample the SSC field
+   *
+   * Wrapped from Radiation::ResetWithSSCTargetPhotons
+   */
   void ResetWithSSCTargetPhotons(int i, int steps=100);
+  /**
+   * @short Returns the Inverse Compton loss lookup.
+   *
+   * @param i : index of photon field. If -1,
+   *            lookup for the sum of target photon fields.
+   *
+   * @return Inverse Compton Loss Lookup as vector of 2D tuples
+   *         energy [erg], energy loss rate from IC scattering [erg/s]
+   *
+   * Wrapped from Radiation::GetICLossLookup
+   */
   vector<vector<double> > GetICLossLookup(int i=-1) {
     return fRadiation->GetICLossLookup(i);
-  };///< return TotalTargetPhotonVector
+  };
+  /**
+   * @short Returns the energy density of the \i target photon field
+   *
+   * @param i : index of photon field.
+   *
+   * @return enregy density in [erg/cm^3]
+   *
+   * Wrapped from Radiation::GetTargetPhotonFieldEnergyDensity
+   */
   double GetTargetPhotonFieldEnergyDensity(unsigned int i) {
     return fRadiation->GetTargetPhotonFieldEnergyDensity(i);
   }
-  void CheckSanityOfTargetPhotonLookup(); // wrapped from Radiation class. See Docu there.
-  vector<vector<double> > GetTargetPhotons(int i=-1); // wrapped from Radiation class. See Docu there.
-  void ClearTargetPhotons(); // wrapped from Radiation class. See Docu there.
-
+  /// Not doing anything at the moment
+  void CheckSanityOfTargetPhotonLookup();
+  /**
+   * @short Get Target photon \a i.
+   *
+   * @param i : index of photon field. If -1, returns the sum of photon fields
+   *
+   * @return vector of 2D tuples (E, dn/dE) ([erg],[erg^-1])
+   *
+   * Wrapped from Radiation::GetTargetPhotonFieldEnergyDensity
+   */
+  vector<vector<double> > GetTargetPhotons(int i=-1);
+  /**
+   * @short Clear all target photons
+   *
+   * Wrapped from Radiation::GetTargetPhotons
+   */
+  void ClearTargetPhotons();
+ /**
+  * @short Externally switch the parameterisation of the synchrotron emission.
+  *
+  * @param SYNCHMODEL : See Radiation::SynchModel
+  *
+  * Wrapped from Radiation::SetSynchrotronEmissionModel
+  */
   void SetSynchrotronEmissionModel(int SYNCHMODEL) {
     fRadiation->SetSynchrotronEmissionModel(SYNCHMODEL);
-  }  ///< externally switch the parameterisation of the synchrotron emission
-     ///model. See SynchModel docu for options.
+  }
+  /**
+   * @short Find the equilibrium point between Synchrotron and SSC cooling.
+   *
+   * Function under construction! Use at own peril!
+   *
+   * To work the SSC must be the last target field added to list.
+   *
+   * @param tolerance : level of precision between the calculated particle energy and
+   *                    the initial total particle energy, to make sure of consistency
+   * @param bins : bins for the sampling of the SSC spectrum
+   * @return vector of total particles energy at each iteration (for debug purposes)
+   */
   vector<double> CalculateSSCEquilibrium(double tolerance = 5e-2, int bins = 100);
+  /**
+   * @short Set fastmode for grid solver
+   *
+   * See Particles::FASTMODE
+   */
   void SetFastIteration() {FASTMODE = true;}
+  /**
+   * @short Set precision solver for the grid
+   *
+   * See Particles::FASTMODE
+   */
   void SetPreciseIteration() {FASTMODE = false;}
+  /**
+   * @short Return number of initialized target photon fields
+   *
+   * Wrapped from Radiation::GetTargetFieldCount
+   */
   int GetTargetFieldCount(){ return fRadiation->GetTargetFieldCount();}
   /*********************************************************/
   /* DEPRECATED FUNCTIONS KEPT FOR BACKWARDS COMPATIBILITY */

--- a/include/Radiation.h
+++ b/include/Radiation.h
@@ -285,6 +285,8 @@ class Radiation {
   bool SPATIALDEP_CURRENT; ///< boolean state if the absorption target field has a homogeneous density or not
   vector <bool> SPATIALDEP; ///< vector of booleans to state which photon field has a spatial dependency
 
+  double AtomicNumber(double mass_number);  ///< Returns the average atomic number for a given mass number
+
 
  public:
   Radiation();                                       ///< standard constructor

--- a/include/Radiation.h
+++ b/include/Radiation.h
@@ -289,15 +289,22 @@ class Radiation {
 
 
  public:
-  Radiation();                                       ///< standard constructor
-  ~Radiation();                                      ///< standard destructor
-  void SetProtons(vector<vector<double> > PROTONS);  ///< Set Protons
-  void SetElectrons(vector<vector<double> > ELECTRONS);  ///< Set Electrons
-  void SetElectronsIsotropic(void);    ///<Setting isotropic electrons variable to true for anisotropic IC scattering
+  /// standard constructor
+  Radiation();
+  /// standard destructor
+  ~Radiation();
+  /// Set Protons
+  void SetProtons(vector<vector<double> > PROTONS);
+  /// Set Electrons
+  void SetElectrons(vector<vector<double> > ELECTRONS);
+  /// Setting isotropic electrons variable to true for anisotropic IC scattering
+  void SetElectronsIsotropic(void);
   
-  
+  /// Add hadronic species
   void AddHadrons(vector<vector<double> > Spectrum, double Mass_number);
+  /// Return hadron spectrum number \a i
   vector <vector <double> > GetHadrons(int i);
+  /// Return vector with the atomic masses of the injected hadrons
   vector< double > GetHadronMasses(void);
   void SetAmbientMediumComposition(vector<vector< double > > composition);
   vector<vector<double> > GetAmbientMediumComposition(void);
@@ -306,101 +313,111 @@ class Radiation {
   
   double TestHadronLookup(int i, double e); // TEST: Function exists only for
                                                         // testing purposes of lookups
-  
-  
-   
-
-
+  /// Calculate epsilon factor for hadronic interactions
   double CalculateEpsilon(double Tp, double Mass);
-  
+  /// Calculates the nucleus-nucleus reaction cross section
   double NuNuXSection(double ProjMass, double TargetMass);
-
-  
+  /// return proton spectrum return format: 2D vector
   vector<vector<double> > GetProtonVector() {
     return ProtonVector;
-  }  ///< return proton spectrum return format: 2D vector
+  }
+  /// return electron spectrum return format: 2D vector
   vector<vector<double> > GetElectronVector() {
     return ElectronVector;
-  }  ///< return electron spectrum return format: 2D vector
-  void SetAmbientDensity(double N);  ///< set ambient number density (cm^-3). Assumes protons and 10% Helium
+  }
+  /// Set ambient number density (cm^-3). Assumes protons and 10% Helium
+  void SetAmbientDensity(double N);
+  /// get ambient number density (cm^-3). Assumes protons and 10% Helium
   double GetAmbientDensity() {
     return n;
-  }  ///< get ambient number density (cm^-3). Assumes protons and 10% Helium
+  }
+  /// Calculates the differential photon emission at energy 'e' [erg]
   void CalculateDifferentialGammaEmission(double e, int particletype);
+  /// Calculate differential photon spectrum between emin and emax
   void CalculateDifferentialPhotonSpectrum(int steps = 100, double emin = 0.,
                                            double emax = 0.);
+  /// Calculate differential photon spectrum at given \a points
   void CalculateDifferentialPhotonSpectrum(vector<double> points);
+  /**
+   * Return the differential photon spectra
+   * dN/dE [number of photons/(erg*s*cm^2)] vs E [erg] in a 2D-Vector
+   * */
   vector<vector<double> > ReturnDifferentialPhotonSpectrum(int i,
                                                            double emin,
                                                            double emax,
                                                   vector< vector<double> > vec);
+  /// returns SED for emission component \a i as 2D vector
   vector<vector<double> > ReturnSED(int i, double emin,double emax, 
-                                      vector< vector<double> > vec);  ///< returns SED for
-                                                        ///emission component i
-                                                        ///as 2D vector
+                                      vector< vector<double> > vec);
+  /// set the source B-Field (G)
   void SetBField(double BFIELD) {
     BField = BFIELD;
-  }  ///< set the source B-Field (G)
+  }
+  /// Return B field [G]
   double GetBField() {return BField;}
+  /// set the distance to the source (\a d to be given in units of parsecs)
   void SetDistance(double d) {
     distance = d*pc_to_cm;
-  }  ///< set the distance to the source (\a d to be given in units of parsecs)
+  }
+  /**
+   * Get Radiation::fdiffIC.
+   *  \a i to retrieve different components. With \a i = -1 (DEFAULT),
+   *  returns the total IC components
+   */
   double GetDifferentialICFlux(int i=-1) { 
     if(i<-1) return 0.;
     else if(i==-1) return fdiffic;
-    else return fdiffics[i]; }        ///< get Radiation::fdiffIC. \a i to retrieve different components. With \a i = -1 (DEFAULT), returns the total IC components
-  double GetDifferentialSynchFlux() { return fdiffsynch; }  ///< get Radiation::fdiffsynch
-  double GetDifferentialBremsFlux() { return fdiffbrems; }  ///< get Radiation::fdiffbrems
-  double GetDifferentialPPFlux() { return fdiffpp; }        ///< get Radiation::fdiffpp
-  vector<double> GetDifferentialHadronFlux() { return fdiffhadr; } ///< get Radiation::fdiffhadr
+    else return fdiffics[i]; }
+  /// Get Radiation::fdiffsynch
+  double GetDifferentialSynchFlux() { return fdiffsynch; }
+  /// Get Radiation::fdiffbrems
+  double GetDifferentialBremsFlux() { return fdiffbrems; }
+  /// get Radiation::fdiffpp
+  double GetDifferentialPPFlux() { return fdiffpp; }
+  /// get Radiation::fdiffhadr
+  vector<double> GetDifferentialHadronFlux() { return fdiffhadr; }
+  /**
+   * Get integrated gamma-ray flux between emin and emax (erg)
+   * summed over all radiation processes. Using Radiation::GetIntegratedFlux
+   */
   double GetIntegralTotalFlux(double emin, double emax) {  
-    return GetIntegratedFlux(1,emin,emax); }               ///< get integrated gamma-ray flux between
-                                                           ///< emin and emax (erg) 
-                                                           ///< summed over all 
-                                                           ///< radiation processes
-                                                           ///< Using Radiation::GetIntegratedFlux
-                                                         
+    return GetIntegratedFlux(1,emin,emax); }
+  /**
+   * get integrated gamma-ray flux between emin and emax (erg) from
+   * proton-proton interaction Using Radiation::GetIntegratedFlux
+   */
   double GetIntegralPPFlux(double emin, double emax) {  
-    return GetIntegratedFlux(2,emin,emax); }           ///< get integrated gamma-ray flux between
-                                                       ///< emin and emax (erg) 
-                                                       ///< from proton-proton
-                                                       ///< interaction
-                                                       ///< Using Radiation::GetIntegratedFlux
-                                                         
+    return GetIntegratedFlux(2,emin,emax); }
+  /**
+   * get integrated gamma-ray flux between emin and emax (erg) from
+   * IC-mechanism Using Radiation::GetIntegratedFlux
+   */
   double GetIntegralICFlux(double emin, double emax) { 
-    return GetIntegratedFlux(3,emin,emax); }           ///< get integrated gamma-ray flux between
-                                                       ///< emin and emax (erg) 
-                                                       ///< from IC-mechanism
-                                                       ///< Using Radiation::GetIntegratedFlux
-                                                         
+    return GetIntegratedFlux(3,emin,emax); }
+  /**
+   * get integrated gamma-ray flux between emin and emax (erg) from
+   * Bremsstrahlung Using Radiation::GetIntegratedFlux
+   */
   double GetIntegralBremsstrahlungFlux(double emin, double emax) { 
-    return GetIntegratedFlux(4,emin,emax); }             ///< get integrated 
-                                                         ///< gamma-ray flux between
-                                                         ///< emin and emax (erg) 
-                                                         ///< from Bremsstrahlung
-                                                         ///< Using Radiation::GetIntegratedFlux
-                                                         
+    return GetIntegratedFlux(4,emin,emax); }
+  /**
+   * get integrated gamma-ray flux between emin and emax (erg) from
+   * synchrotron Using Radiation::GetIntegratedFlux
+   */
   double GetIntegralSynchrotronFlux(double emin, double emax) { 
-    return GetIntegratedFlux(5,emin,emax); }               ///< get integrated 
-                                                           ///< flux between
-                                                           ///< emin and emax (erg) 
-                                                           ///< from synchrotron
-                                                           ///< process.
-                                                           ///< Using Radiation::GetIntegratedFlux
-                                                         
+    return GetIntegratedFlux(5,emin,emax); }
+  /**
+   * get integrated gamma-ray flux between emin and emax (erg) summed over all
+   * radiation processes Using Radiation::GetIntegratedFlux
+   */
   double GetIntegralTotalEnergyFlux(double emin, double emax) { 
-    return GetIntegratedFlux(1,emin,emax,true); }        ///< get integrated energy flux between
-                                                         ///< emin and emax (erg) 
-                                                         ///< summed over all 
-                                                         ///< radiation processes
-                                                         ///< Using Radiation::GetIntegratedFlux
-                                                         
+    return GetIntegratedFlux(1,emin,emax,true); }
+  /**
+   * get integrated energy flux between emin and emax (erg) from proton-proton
+   * processes Using Radiation::GetIntegratedFlux
+   */
   double GetIntegralPPEnergyFlux(double emin, double emax) { 
-    return GetIntegratedFlux(2,emin,emax,true); }        ///< get integrated energy flux between
-                                                         ///< emin and emax (erg) 
-                                                         ///< from proton-proton
-                                                         ///< interaction
-                                                         ///< Using Radiation::GetIntegratedFlux
+    return GetIntegratedFlux(2,emin,emax,true); }
                                                          
   double GetIntegralICEnergyFlux(double emin, double emax) { 
     return GetIntegratedFlux(3,emin,emax,true); }        ///< get integrated energy flux between
@@ -509,19 +526,27 @@ class Radiation {
     return SynchModel;
   }  ///< return the parameterisation of the synchrotron emission model. See Radiation::SynchModel docu for options.
   void CheckSanityOfTargetPhotonLookup();
+  /// Return proton SED See: Radiation::GetPaticleSED
   vector< vector<double> > GetProtonSED() {return GetParticleSED("protons");}
+  /// Return electron SED See: Radiation::GetPaticleSED
   vector< vector<double> > GetElectronSED() {return GetParticleSED("electrons");}
   Utils *fUtils;
+  /// Set up anisotropy for target photon \a i accounting for observation angle
   void SetTargetPhotonAnisotropy(int i, vector<double> obs_angle, 
                                  vector<double> phi, vector<double> theta, 
                                  vector< vector<double> > mesh);
+  /// Set up anisotropy for target photon \a i
   void SetTargetPhotonAnisotropy(int i, vector<double> phi, vector<double> theta, 
                                           vector< vector<double> > mesh);
+  /// Return Anysotropy vector for target photon \a i
   vector< vector<double> > GetTargetPhotonAnisotropy(int i, 
                                      vector<double> phi, vector<double> theta);
+  /// Set the pitch angle for the synchrotron emission [rad]
   void SetSynchrotronPitchAngle(double synchangle) {SynchAngle = synchangle;}
+  /// Set the interpolation method. See Utils::SetInterpolationMethod
   void SetInterpolationMethod(string intermeth)
     {fUtils->SetInterpolationMethod(intermeth);}
+  /// Return differential pp cross section
   double DiffPPXSection(double Tp, double Eg);
   double MeanMultiplicity(double Tp);
   double Amax(double Tp);
@@ -544,25 +569,33 @@ class Radiation {
   bool GetQuietMode() {return QUIETMODE;}
   void ToggleVerboseMode() { VERBOSEMODE = VERBOSEMODE == true ? false : true; }  ///< enable verbose mode (more cout output)
   bool GetVerboseMode() {return VERBOSEMODE;}
+  /// Wrapper around Radiation::ICEmissivity
   double ICEmissivityWrapper(double e_ph, double e_e, double e_g);
+  /// Wrapper around Radiation::ICEmissivityAnisotropic
   double ICEmissivityAnisotropicWrapper(double e_ph, double e_e, double e_g);
 /*  vector< vector<double> > GetTargetPhotonFieldVector(unsigned int i){*/
 /*    vector< vector<double> >v = fUtils->VectorAxisPow10(TargetPhotonVectors[i],-1);*/
 /*    return v;}*/
+  /// Return emergy density of target field \a i. See Radiation::TargetPhotonEdensities
   double GetTargetPhotonFieldEnergyDensity(unsigned int i) {
     return TargetPhotonEdensities[i];
   }
+  /// Return target field \a i anisotropy map. See Radiation::TargetPhotonAngularDistrsVectors
   vector< vector<double> > GetTargetFieldAnisotropyMap(int i) {
     if (i>(int)RADFIELDS_MAX) cout<<"Radiation::GetTargetFieldAnisotropyMap: invalid index "<<i<<". Returning"
           "empty vector." <<endl;
     return TargetPhotonAngularDistrsVectors[i];}
 
   void ClearTargetPhotonField(int i); ///< reset values for target photon field component i
+  /// Remove the last target field that has been added
   void RemoveLastICTargetPhotonComponent() {
     ClearTargetPhotonField(--RADFIELD_COUNTER);
   }
+  /// Return sum of the isotropic target photon field
   vector< vector<double> > SumTargetFields(int bins,bool ISO=true);
+  /// Fill
   void SumTargetFieldsAll(int bins=1000);
+  /// Fill
   void SumTargetFieldsIsotropic(int bins=1000);
 
   unsigned int GetTargetFieldCount(){return RADFIELD_COUNTER;}
@@ -577,30 +610,37 @@ class Radiation {
   double GetSizePhotonField(int i);
   void SetTargetFieldSpatialDep(int i, vector< vector<double> > SpatialDep); ///< Set the spatial dependence for the Target field
   vector< vector<double> > GetTargetFieldSPatialDep(int i);  ///< Return the spatial dependency of the photon field (space in cm)
-  double AverageSigmaGammaGamma(double Eph1, double Eph2);             // Average cross section for isotropic and homogeneous case
-  double SigmaGammaGamma(double Eph1, double Eph2, double costheta);      // Full gamma-gamma cross section
+  double AverageSigmaGammaGamma(double Eph1, double Eph2);             ///< Average cross section for isotropic and homogeneous case
+  double SigmaGammaGamma(double Eph1, double Eph2, double costheta);      ///< Full gamma-gamma cross section
   double ComputeAbsCoeff(double Egamma, int target);  ///< Auxiliary function to compute only the absorption coefficient, no spatial integration
   double ComputeOptDepth(double Egamma, int target, double phsize);
-  double ComputeOptDepthIsotropic(double Egamma, int target, double phsize); // Computation of the optical depth parameter isotropic only
+  double ComputeOptDepthIsotropic(double Egamma, int target, double phsize); ///< Computation of the optical depth parameter isotropic only
+  /// Wrapper around function Radiation::ReturnSED to return the gamma-gamma absorbed values
   vector< vector<double> > ReturnAbsorbedSEDonFields(double emin, double emax, 
-                                                         vector <int> fields, vector <double> size); // Wrapper around function ReturnSED to return the gamma-gamma absorbed values
+                                                         vector <int> fields, vector <double> size);
+  /// Wrapper around function Radiation::ReturnDifferentialPhotonSpectrum to return the gamma-gamma absorbed values
   vector< vector<double> > ReturnAbsorbedSpectrumOnFields(double emin, double emax, 
-                                                         vector <int> fields, vector <double> size); // Wrapper around function ReturnDifferentialPhotonSpectrum to return the gamma-gamma absorbed values
+                                                         vector <int> fields, vector <double> size);
+  /// Return SED absorbed by gamma gamma on fields \a i
   vector<vector<double> > GetTotalAbsorbedSpectrum(vector <int> fields, double emin = 0., double emax = 0.) {
     return ReturnAbsorbedSpectrumOnFields(emin, emax, fields, sizephfield);
   }
+  /// return total absorbed SED on selected fields, default behaviour should be to use all of them. TODO
   vector<vector<double> > GetTotalAbsorbedSED(vector <int> fields, double emin = 0., double emax = 0.) {
     return ReturnAbsorbedSEDonFields(emin, emax, fields, sizephfield);
-  }  ///< return total absorbed SED on selected fields, default behaviour should be to use all of them. TODO
+  }
+  /// Returns the absorbed integrated flux.
   double ReturnAbsorbedIntergratedFlux(double emin, double emax, bool ENERGYFLUX,vector <int> fields, vector <double> size);
   
-  double GetIntegralTotalAbsEnergyFlux(double emin, double emax, vector <int> fields) { ///< get integrated 
-    return ReturnAbsorbedIntergratedFlux(emin,emax,true,fields,sizephfield); }                      /// absorbed energy flux between
+  double GetIntegralTotalAbsEnergyFlux(double emin, double emax, vector <int> fields) {
+    return ReturnAbsorbedIntergratedFlux(emin,emax,true,fields,sizephfield); }            ///< get integrated
+                                                                                          /// absorbed energy flux between
                                                                                           /// emin and emax (erg) 
                                                                                           /// summed over all 
                                                                                           /// radiation processes
-  double GetIntegralTotalAbsFlux(double emin, double emax, vector <int> fields) { ///< get integrated 
-    return ReturnAbsorbedIntergratedFlux(emin,emax,false,fields,sizephfield); }                      /// absorbed energy flux between
+  double GetIntegralTotalAbsFlux(double emin, double emax, vector <int> fields) {
+    return ReturnAbsorbedIntergratedFlux(emin,emax,false,fields,sizephfield); }           ///< get integrated
+                                                                                          /// absorbed energy flux between
                                                                                           /// emin and emax (erg) 
                                                                                           /// summed over all 
                                                                                           /// radiation processes

--- a/include/Radiation.h
+++ b/include/Radiation.h
@@ -458,58 +458,61 @@ class Radiation {
   void Reset();  ///< reset ParticleLookup, Electrons, Protons, fintbrems,
                  ///lintbrems, fintpp, lintpp, fintic, lintic
   vector<vector<double> > GetICLossLookup(int i=-1);///< return TotalTargetPhotonVector
+  /// Returns distance of the source in pc
   double GetDistance() {return distance/pc_to_cm;}
   vector<vector<double> > GetTotalSpectrum(double emin = 0., double emax = 0.) {
     return ReturnDifferentialPhotonSpectrum(1, emin, emax, diffSpec);
-  }  ///< return total spectrum
+  }  ///< return total spectrum between emin and emax (in erg)
   vector<vector<double> > GetPPSpectrum(double emin = 0., double emax = 0.) {
     return ReturnDifferentialPhotonSpectrum(2, emin, emax, diffSpec);
-  }  ///< return pi0 decay spectrum
+  }  ///< return pi0 decay spectrum between emin and emax (in erg) - protons + helium only
   vector<vector<double> > GetICSpectrum(double emin = 0., double emax = 0.) {
     return ReturnDifferentialPhotonSpectrum(3, emin, emax, diffSpec);
-  }  ///< return total Inverse-Compton spectrum
+  }  ///< return total Inverse-Compton spectrum between emin and emax (in erg)
   vector<vector<double> > GetBremsstrahlungSpectrum(double emin = 0.,
                                                     double emax = 0.) {
     return ReturnDifferentialPhotonSpectrum(4, emin, emax, diffSpec);
-  }  ///< return Bremsstrahlung spectrum
+  }  ///< return Bremsstrahlung spectrum between emin and emax (in erg)
   vector<vector<double> > GetSynchrotronSpectrum(double emin = 0.,
                                                  double emax = 0.) {
     return ReturnDifferentialPhotonSpectrum(5, emin, emax, diffSpec);
-  }  ///< return Synchrotron spectrum
+  }  ///< return Synchrotron spectrum between emin and emax (in erg)
   vector<vector<double> > GetHadronSpectrum(double emin = 0.,
                                                 double emax = 0.) {
     return ReturnDifferentialPhotonSpectrum(6, emin, emax, diffSpec);
-  }  ///< return Hadron spectrum                                            
+  }  ///< Return total pi0 decay (from more hadronic species) spectrum between emin and emax (in erg)
                                             
   vector<vector<double> > GetTotalSED(double emin = 0., double emax = 0.) {
     return ReturnSED(1, emin, emax, diffSpec);
-  }  ///< return total SED
+  }  ///< Return total SED between emin and emax (in TeV)
   vector<vector<double> > GetPPSED(double emin = 0., double emax = 0.) {
     return ReturnSED(2, emin, emax, diffSpec);
-  }  ///< return pi0 decay SED
+  }  ///< Return pi0 decay SED between emin and emax (in TeV) - protons + helium only
   vector<vector<double> > GetICSED(double emin = 0., double emax = 0.) {
     return ReturnSED(3, emin, emax, diffSpec);
-  }  ///< return Inverse Compton SED
+  }  ///< Return Inverse Compton SED between emin and emax (in TeV)
   vector<vector<double> > GetBremsstrahlungSED(double emin = 0.,
                                                double emax = 0.) {
     return ReturnSED(4, emin, emax, diffSpec);
-  }  ///< return Bremsstrahlung SED
+  }  ///< Return Bremsstrahlung SED between emin and emax (in TeV)
   vector<vector<double> > GetSynchrotronSED(double emin = 0.,
                                             double emax = 0.) {
     return ReturnSED(5, emin, emax, diffSpec);
-  }  ///< return Synchrotron SED
+  }  ///< Return Synchrotron SED between emin and emax (in TeV)
   vector<vector<double> > GetHadronSED(double emin = 0.,
                                             double emax = 0.) {
     return ReturnSED(6, emin, emax, diffSpec);
-  }  ///< return Hadron SED
+  }  ///< Return total pi0 decay (from more hadronic species) SED between emin and emax (in TeV)
 
-  
-  vector<vector<double> > GetICSpectrum(unsigned int i, double emin = 0., double emax = 0.); ///< return Inverse Compton spectrum
-  vector<vector<double> > GetICSED(unsigned int i, double emin = 0., double emax = 0.); ///< return Inverse Compton SED
+  /// Returns IC spectrum for target field \a i
+  vector<vector<double> > GetICSpectrum(unsigned int i, double emin = 0., double emax = 0.);
+  /// Returns IC SED for target field \a i
+  vector<vector<double> > GetICSED(unsigned int i, double emin = 0., double emax = 0.);
 
-
-  vector<vector<double> > GetHadronSpectrum(unsigned int i, double emin = 0., double emax = 0.); ///< return Hadron spectrum from component i
-  vector<vector<double> > GetHadronSED(unsigned int i, double emin = 0., double emax = 0.); ///< return Hadron SED from component i 
+  /// Return pi0 decay spectrum from hadronic component i
+  vector<vector<double> > GetHadronSpectrum(unsigned int i, double emin = 0., double emax = 0.);
+  /// Return pi0 decay SED from hadronic component i
+  vector<vector<double> > GetHadronSED(unsigned int i, double emin = 0., double emax = 0.);
   
   
   Radiation *Clone() { return this; }
@@ -518,7 +521,7 @@ class Radiation {
   }  ///< externally switch the parameterisation of the pp emission model. See Radiation::PiModel documentation for options.
   int GetPPEmissionModel() {
     return PiModel;
-  }  ///< return the parameterisation of the pp emission model. See Radiation::PiModel docu for options.
+  }  ///< return the parametrisation of the pp emission model. See Radiation::PiModel docu for options.
   void SetSynchrotronEmissionModel(int SYNCHMODEL) {
     SynchModel = SYNCHMODEL;
   }  ///< externally switch the parameterisation of the synchrotron emission model. See Radiation::SynchModel docu for options.
@@ -547,7 +550,7 @@ class Radiation {
   void SetInterpolationMethod(string intermeth)
     {fUtils->SetInterpolationMethod(intermeth);}
   /// Return differential pp cross section
-  double DiffPPXSection(double Tp, double Eg);
+  double DiffPPXSection(double Tp, double Eg); // bring all these in private?
   double MeanMultiplicity(double Tp);
   double Amax(double Tp);
   double F(double Tp, double Eg);
@@ -566,9 +569,9 @@ class Radiation {
 /*    cos_theta_e = cos(theta_e);*/
 /*    return;}*/
   void ToggleQuietMode() { QUIETMODE = QUIETMODE == true ? false : true; }  ///< enable quiet mode (very little cout output)
-  bool GetQuietMode() {return QUIETMODE;}
+  bool GetQuietMode() {return QUIETMODE;} ///< Return quitemode status
   void ToggleVerboseMode() { VERBOSEMODE = VERBOSEMODE == true ? false : true; }  ///< enable verbose mode (more cout output)
-  bool GetVerboseMode() {return VERBOSEMODE;}
+  bool GetVerboseMode() {return VERBOSEMODE;} ///< Return verbosemode status
   /// Wrapper around Radiation::ICEmissivity
   double ICEmissivityWrapper(double e_ph, double e_e, double e_g);
   /// Wrapper around Radiation::ICEmissivityAnisotropic
@@ -576,11 +579,18 @@ class Radiation {
 /*  vector< vector<double> > GetTargetPhotonFieldVector(unsigned int i){*/
 /*    vector< vector<double> >v = fUtils->VectorAxisPow10(TargetPhotonVectors[i],-1);*/
 /*    return v;}*/
-  /// Return emergy density of target field \a i. See Radiation::TargetPhotonEdensities
+  /// Return energy density of target field \a i. See Radiation::TargetPhotonEdensities
   double GetTargetPhotonFieldEnergyDensity(unsigned int i) {
     return TargetPhotonEdensities[i];
   }
-  /// Return target field \a i anisotropy map. See Radiation::TargetPhotonAngularDistrsVectors
+  /**
+   * @short Return target field \a i anisotropy map. See Radiation::TargetPhotonAngularDistrsVectors
+   *
+   * @param i : index of the target photon field to consider
+   * @return 2D vector with the value of the anisotropy distribution. The corresponfing angular values
+   * are in Radiation::TargetPhotonAngularPhiVectors and Radiation::TargetPhotonAngularThetaVectors
+   * (first and second coordinate respectively).
+   */
   vector< vector<double> > GetTargetFieldAnisotropyMap(int i) {
     if (i>(int)RADFIELDS_MAX) cout<<"Radiation::GetTargetFieldAnisotropyMap: invalid index "<<i<<". Returning"
           "empty vector." <<endl;
@@ -591,22 +601,28 @@ class Radiation {
   void RemoveLastICTargetPhotonComponent() {
     ClearTargetPhotonField(--RADFIELD_COUNTER);
   }
+
+  // these functions should be private!
   /// Return sum of the isotropic target photon field
   vector< vector<double> > SumTargetFields(int bins,bool ISO=true);
-  /// Fill
+  /// Sum all the target fields and pushes them in Radiation::SetTargetPhotonVectorLookup
   void SumTargetFieldsAll(int bins=1000);
-  /// Fill
+  /// Sum all the isotropic target fields and pushes them in Radiation::SetTargetPhotonVectorLookup
   void SumTargetFieldsIsotropic(int bins=1000);
 
+  /// Return the counter of number of target radiation fields. See Radiation::RADFIELD_COUNTER
   unsigned int GetTargetFieldCount(){return RADFIELD_COUNTER;}
+  /// Set up fast calculation of Inverse Compton. See Radiation::FASTMODE_IC
   void SetICFastMode() {FASTMODE_IC = true;}
+  /// Unset up fast calculation of Inverse Compton. See Radiation::FASTMODE_IC
   void UnsetICFastMode() {FASTMODE_IC = false;}
-  
+  /// Set the spatial size of the photon field \a i
   void SetSizePhotonField(int i, double size);
-  
+  /// Clear all the sizes of the target photon fields
   void ClearPhotonFieldSize();
-  
-  vector <double> GetSizePhotonField(); //get the photon field
+  /// Get the vector of photon field sizes
+  vector <double> GetSizePhotonField();
+  /// Return the size of the photon field \a i
   double GetSizePhotonField(int i);
   void SetTargetFieldSpatialDep(int i, vector< vector<double> > SpatialDep); ///< Set the spatial dependence for the Target field
   vector< vector<double> > GetTargetFieldSPatialDep(int i);  ///< Return the spatial dependency of the photon field (space in cm)

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -105,21 +105,33 @@ class Utils {
   gsl_interp_accel *yacc;
 
  public:
+  /// Constructor
   Utils(bool DRAWLOGO = false);
+  /// Destructor
   ~Utils();
+  /// Generic parameter file reading function
   int ReadParameterFile(string inputname, vector<string> parameter_names,
                         vector<string> files_names,
                         vector<double> &parameter_values,
                         vector<string> &files);
+  /// Draw the GAMERA logo
   void DrawGamera();
+  /// Draw the GAPPA logo
   void DrawGappa();
+  /// Write spectrum on file
   void WriteOut(vector<vector<double> > sp, string outname);
+  /// Read a spectrum from file
   void ReadIn(string inname, vector< vector<double> > &sp);
+  /// Random number generator [0,1)
   double Random();
+  /// Get n uniform random numbers in [x_min,x_max)
   vector<double>  UniformRandom(double x_min, double x_max,int n);
+  /// Get linearly distributed variates
   vector<double>  LinearRandom(double slope, double x_min, double x_max, int n);
+  /// Get power-law distributed variates
   vector<double>  PowerLawRandom(double index, double x_min, double x_max,
                                  int n);
+  /// Get random numbers with gaussian distribution
   vector<double>  GaussianRandom(double width, double offset, int n);
   vector<double>  SignRandom(int n);
   vector<double>  ExponentialRandom(double ind_norm, double x_min,

--- a/src/Particles.C
+++ b/src/Particles.C
@@ -285,7 +285,11 @@ double Particles::SourceSpectrum(double e) {
 }
 
 /**
- * Escape time at energy e (erg) and time t (yrs).
+ * Escape time at energy \a e (erg) and time \a t (yrs).
+ *
+ * @param e : energy of the particle [erg]
+ * @param t : time [yr]
+ * @return escape time of the particle in yr
  */
 double Particles::EscapeTime(double e, double t) {
   // energy and time dependent escape -> 2D intepolation in t,e lookup
@@ -310,9 +314,15 @@ double Particles::EscapeTime(double e, double t) {
   else return 0.;
 }
 
-// This is perhaps outdated, as custom injection functions also cover this
-// special case. FIXME: Remove this?
-// *Advised to use the Particles::CustomInjectionSpectrum function*
+/**
+ * Power law injection spectrum. If eBreak and SpectralIndex2 are specified,
+ * returns a broken power law.
+ *
+ * This is perhaps outdated, as custom injection functions also cover this
+ * special case. FIXME: Remove this?
+ * Advised to use the Particles::CustomInjectionSpectrum function*
+ *
+ */
 double Particles::PowerLawInjectionSpectrum(double e, double ecut,
                                             double emax) {
 
@@ -636,8 +646,14 @@ double Particles::EnergyLossRate(double E) {
   return synchl + icl + adl + bremsl + ionization + ppcol;
 }
 
-/** Prepare axes for the numerical solver (and if onlyprepare==false) call the
- *  solver
+/**
+ * Prepare axes for the numerical solver (and if onlyprepare==false) call the
+ * solver
+ *
+ * @param particlespectrum : spectrum of the particles
+ * @param onlyprepare : if false, calls the solver and initialise
+ *                      the grid (default false)
+ * @param dontinitialise : if false, sets the initial conditions (default false)
  */
 void Particles::PrepareAndRunNumericalSolver(
     vector<vector<double> > &particlespectrum, bool onlyprepare,
@@ -655,7 +671,9 @@ void Particles::PrepareAndRunNumericalSolver(
   return;
 }
 
-/** create an axis that attributes each bin with a real value. */
+/**
+ * create an axis that attributes each bin with a real value. (e.g. time axis, energy axis).
+ */
 void Particles::GetAxis(double min, double max, int steps, vector<double> &Axis,
                         bool logarithmic) {
 
@@ -682,7 +700,8 @@ void Particles::GetAxis(double min, double max, int steps, vector<double> &Axis,
   return;
 }
 
-/** create the propagation grid out of 2 1D-vectors
+/**
+ * create the propagation grid out of 2 1D-vectors
  * energy in x-direction, time in y-direction
  */
 void Particles::CreateGrid() {
@@ -694,10 +713,15 @@ void Particles::CreateGrid() {
   return;
 }
 
-/** determine the minimum time from where to start
+/**
+ * Determine the minimum time from where to start
  * the calculation. Electrons before that time are injected as
  * a single 'blob'. This time is derived from the requirement
  * that the blob has slid down to energies e.g. E<1GeV(EMIN) at t=Age.
+ *
+ * @param emin : lost energy at time t=age
+ * @param tmin : pointer to the time
+ *
  */
 void Particles::DetermineTMin(double emin, double &tmin) {
   double logt, logtmin, logtmax, logdt, logsteps, TMIN;
@@ -724,7 +748,8 @@ void Particles::DetermineTMin(double emin, double &tmin) {
   return;
 }
 
-/** Determine the maximum energy of particles between tmin and Age.
+/**
+ * Determine the maximum energy of particles between tmin and Age.
  * This energy is then used as upper boundary for the energy dimension of the
  * grid.
  */
@@ -1084,7 +1109,8 @@ double Particles::MinMod(double a, double b) {
     return 0.;
 }
 
-/** wrapper function to calculate the grid only in a specified time interval dT
+/**
+ * Wrapper function to calculate the grid only in a specified time interval dT
  * = T2-T2
  * This is especially useful for the creation of time-series of spectra and
  * necessary
@@ -1206,6 +1232,9 @@ void Particles::CalcSpecSemiAnalyticConstELoss() {
 /**
  * Integrand of the time-integration of the semi-analytical solution. 
  * This is an integration over the time energy trajectory of the electron.
+ *
+ * @param T : time
+ * @param par : additional parameters (energy)
  */ 
 double Particles::SemiAnalyticConstELossIntegrand(double T, void *par) {
   if (energyTrajectoryInverse == NULL || energyTrajectory == NULL) {
@@ -1748,14 +1777,13 @@ vector< vector<double> > Particles::GetEnergyLossRateVector(vector<double> epoin
 
 /**
  * Returns the injection spectrum:
- * Arguments:
- *   vector<double> epoints : vector of energies to return the spectrum (erg units)
- *               double age : age at which to return the spectrum (if age not
+ *
+ * @param epoints : vector of energies to return the spectrum (erg units)
+ * @param age : age at which to return the spectrum (if age not
  *                            given, then computes as the injection)
- *                 bool SED : true if the particle spectrum should be returned
+ * @param SED : true if the particle spectrum should be returned
  *                            as E^2dN/dE
- * Returns:
- *   vector< vector<double>> v : vector of tuples (Energy, spectrum)
+ * @return v : vector of tuples (Energy, spectrum)
  *                               energy returned in TeV.
  */
 vector< vector<double> > Particles::GetInjectionSpectrumVector(
@@ -1822,7 +1850,7 @@ vector< vector<double> > Particles::GetQuantityVector(vector<double> epoints,
 
 
 
-/**
+/*
  * Function under construction! Use at own peril!
  * TODO: The handling of the SSC field should be done better. Not sure all the cases
  * are correctly taken into account.

--- a/src/Particles.C
+++ b/src/Particles.C
@@ -373,8 +373,10 @@ double Particles::PowerLawInjectionSpectrum(double e, double ecut,
 }
 
 /** 
- * Set important class members to values at time t.
- * Time in years
+ * Set the values for the class variables and lookups like:
+ * Bfield, Luminosity, Maximum energy, density.
+ *
+ * @param time to be given in units of years
  */
 void Particles::SetMembers(double t) {
   if (t < TminInternal || t > TmaxInternal) {
@@ -1377,8 +1379,8 @@ void Particles::DetermineLookupTimeBoundaries() {
   return;
 }
 
-/**
- * Return a particle SED dN/dE vs E (erg vs TeV)
+/*
+ * Return a particle SED E vs E^2dN/dE (TeV vs erg)
  */
 vector<vector<double> > Particles::GetParticleSED() {
   vector<vector<double> > v;
@@ -1392,8 +1394,8 @@ vector<vector<double> > Particles::GetParticleSED() {
   return v;
 }
 
-/**
- * Return total energy in particles. Input energy bounds in TeV
+/*
+ * Return total energy in particles. Input energy bounds in erg!
  * FIXME:This function sucks, have to think of something better!
  */
 double Particles::GetParticleEnergyContent(double E1, double E2) {
@@ -1430,7 +1432,8 @@ void Particles::SetIntegratorMemory(string mode) {
   }
   return;
 }
-/**
+
+/*
  * Integration function using the GSL QAG functionality
  *
  */
@@ -1460,7 +1463,7 @@ double Particles::Integrate(fPointer f, double *x, double emin, double emax,
   else return integral;
 }
 
-/**
+/*
  * Set a custom injection spectrum. Input is a 2D vector with 2 colums, first
  * column holds energy in erg. 
  * mode = 0 -> custom injection spectrum lookup:
@@ -1517,7 +1520,7 @@ void Particles::SetCustomEnergylookup(vector< vector<double> > vCustom,
   return;    
 }
 
-/**
+/*
  * Set a custom injection spectrum or escape time. Input is a 2D vector with 3 colums.
  * mode 0 = custom injection spectrum: first column holds time in yrs, second 
  * energy in erg, third holds differential rate in 
@@ -1688,7 +1691,7 @@ vector<vector<double> > Particles::GetTargetPhotons(int i) {
  * the loss process. Energy is given in erg.
  */
 double Particles::GetEnergyLossRate(double E, string type, double age) {
-    
+
     if(age) {
         SetMembers(age);
     }
@@ -1709,19 +1712,17 @@ double Particles::GetEnergyLossRate(double E, string type, double age) {
     }
 }
 
-/*
+/**
  * Computes and returns either the energy loss rate of the particle or the
  * cooling time via setting the \a TIMESCALE boolean to false or true
  * respectively
  *
- * Arguments:
- * vector<double> epoints : vector of energies of the particle
- *            string type : process for which you want the information
- *             double age : age at which you want to compute
- *         bool TIMESCALE : 1 for cooling time; 0 for energy loss rate
+ * @param epoints : vector of energies of the particle
+ * @param type : process for which you want the information
+ * @param age : age at which you want to compute
+ * @param TIMESCALE : 1 for cooling time; 0 for energy loss rate
  *
- * Returns:
- * vector< vector<double>> of tuples (energy, value)
+ * @return v as a vector of tuples (energy, value)
  */
 vector< vector<double> > Particles::GetEnergyLossRateVector(vector<double> epoints,
                                                         string type, double age, 

--- a/src/Particles.C
+++ b/src/Particles.C
@@ -386,7 +386,7 @@ double Particles::PowerLawInjectionSpectrum(double e, double ecut,
  * Set the values for the class variables and lookups like:
  * Bfield, Luminosity, Maximum energy, density.
  *
- * @param time to be given in units of years
+ * @param t : time to be given in units of years
  */
 void Particles::SetMembers(double t) {
   if (t < TminInternal || t > TmaxInternal) {

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -361,7 +361,7 @@ double Radiation::DifferentialEmissionComponent(double e, void *par) {
     
     IntFunc = &Radiation::ICEmissivityRadFieldIntegrated;
   } else if (!radiationMechanism.compare("ppEmission")) {
-    if (!n && AmbientMediumComposition.size()) {
+    if (!n && !AmbientMediumComposition.size()) {
       if(!QUIETMODE) cout << "Radiation::DifferentialEmissionComponent:"
                              "No ambient density value set for "
                              "p-p scattering. Returning zero value." << endl;
@@ -380,7 +380,7 @@ double Radiation::DifferentialEmissionComponent(double e, void *par) {
     }
     IntFunc = &Radiation::PPEmissivity;
   } else if (!radiationMechanism.compare("hadronicEmission")) {
-	  if (!n && AmbientMediumComposition.size()) {
+	  if (!n && !AmbientMediumComposition.size()) {
 	    if(!QUIETMODE) cout << "Radiation::DifferentialEmissionComponent:"
 	                           "No ambient density value set for "
 	                           "p-p scattering. Returning zero value." << endl;
@@ -1582,6 +1582,8 @@ void Radiation::SetElectrons(vector<vector<double> > ELECTRONS) {
  * but also arbitrary spectra).
  * 
  * \param PROTONS = vector of tuples (E[erg],N[erg^-1])
+ *
+ * TODO: This function is not really consistent with the AddHadrons
 */
 void Radiation::SetProtons(vector<vector<double> > PROTONS) {
   vector<vector<double> > *pradr = &ProtonVector;
@@ -1673,7 +1675,8 @@ double Radiation::TestHadronLookup(int i, double e){
  * Set the default ambient composition with simply protons and 10% Helium.
  * This is for consistency with Bremsstrahlung and ionization processes
  * which use this default values for the composition of the ISM.
- * Input: proton number density in [cm^-3].
+ *
+ * @param N : proton number density in [cm^-3].
  */
 void Radiation::SetAmbientDensity(double N){
 	n = N; // number density for the protons
@@ -1695,7 +1698,7 @@ void Radiation::SetAmbientMediumComposition(vector<vector< double > > compositio
  
  
 /**
- * Function to return the Hadron spectrum number i.
+ * Function to return the Hadron spectrum number \a i.
  *
  * @param i : Number of the hadron component
  *

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -1179,7 +1179,7 @@ double Radiation::BremsEmissivity(double x, void *par) {
   // double S = n * 1.4; // OLD STUFF
   double S = 0;
   double Se = 0;
-  for (int i=0;i<AmbientMediumComposition.size();i++){
+  for (unsigned int i=0;i<AmbientMediumComposition.size();i++){
      S += AmbientMediumComposition[i][1] * AtomicNumber(AmbientMediumComposition[i][0]) * AtomicNumber(AmbientMediumComposition[i][0]);
      Se += AmbientMediumComposition[i][1] * AtomicNumber(AmbientMediumComposition[i][0]);
   }

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -817,7 +817,7 @@ double Radiation::ICAnisotropicAuxFunc(double phi_p, double theta_p,
  * 
  * \param bins : number of bins in logarithmic energy
  * 
- * Priduces a lookup table with format E[erg] ; -1.*LossrateIC [erg/s]
+ * Produces a lookup table with format E[erg] ; -1.*LossrateIC [erg/s]
  * 
  * It fills the Radiation::ICLossLookupSumIso lookup for all the isotropic fields
  * and and single lookups for each of the anisotropic ones with Radiation::ICLossLookups
@@ -899,6 +899,8 @@ void Radiation::CreateICLossLookup(int bins) {
  * The format of the lookup is: { Energy(erg) - Energy Loss Rate
  * from IC scattering(erg/s) }
  * 
+ * The values are returned as the log10.
+ *
  * The function integrates Radiation::ICEmissivityRadFieldIntegrated for
  * a given energy of the electron and stores the results in Radiation::ICLossVectorCurrent
  * 
@@ -1025,6 +1027,13 @@ void Radiation::CreateICLossLookupIndividual(int i, int bins) {
   return;
 }
 
+/**
+ * Returns the Inverse Compton lookup for losses for the field \a i
+ *
+ * @param i : index of the
+ * @return vector of 2Dtuple with the energy loss for each energy
+ *         log10(E/[erg]) and log10(-dE/dt / [erg/s])
+ */
 vector<vector<double> > Radiation::GetICLossLookup(int i) {
     vector< vector<double> > v;
     if(!RADFIELD_COUNTER) return v;
@@ -1513,7 +1522,8 @@ void Radiation::GetBParams(double Tp, double &b1, double &b2, double &b3) {
  * 
  * \param PARTICLES = a vector of tuples (E; dN/dE)
  * \param type = 0 for electrons; 1 for protons
- * NOTE: Does not work for othe hadrons, use the function AddHadrons() instead
+ *
+ * NOTE: Does not work for the hadrons, use the function AddHadrons() instead
  */
 void Radiation::SetParticles(vector<vector<double> > PARTICLES, int type) {
   if (type && type != 1) {
@@ -1558,7 +1568,7 @@ void Radiation::SetParticles(vector<vector<double> > PARTICLES, int type) {
  * set the Electron spectrum (e.g. calculated in the "Particles" class,
  * but also arbitrary spectra).
  * 
- * \param PROTONS = vector of tuples (E[erg],N[erg^-1])
+ * \param ELECTRONS = vector of tuples (E[erg],N[erg^-1])
 */
 void Radiation::SetElectrons(vector<vector<double> > ELECTRONS) {
   vector<vector<double> > *eladr = &ElectronVector;
@@ -1587,8 +1597,8 @@ void Radiation::SetProtons(vector<vector<double> > PROTONS) {
  * Function to add a spectrum of hadrons with a specific mass number. It also
  * calculates and saves a lookup for the spectrum.
  *
- * @param Spectrum of the hadrons (as vector of 2D-tuples (E,dN/dE) ([erg],[erg^-1]))
- * @param Mass number of the hadrons (number of the nucleons)
+ * @param Spectrum : spectrum of the hadrons (as vector of 2D-tuples (E,dN/dE) ([erg],[erg^-1]))
+ * @param Mass_number : mass number of the hadrons (number of the nucleons)
  *
  */
 void Radiation::AddHadrons(vector<vector<double> > Spectrum, double Mass_number){
@@ -1659,7 +1669,7 @@ double Radiation::TestHadronLookup(int i, double e){
 }
 
 
-/*
+/**
  * Set the default ambient composition with simply protons and 10% Helium.
  * This is for consistency with Bremsstrahlung and ionization processes
  * which use this default values for the composition of the ISM.
@@ -1672,12 +1682,12 @@ void Radiation::SetAmbientDensity(double N){
 }
  
  
-/****************************************************************************
+/**
  * Function to set the composition and the abundances of the ambient medium.
- * Input:  - Vector of tuples containing the mass number (first entry) and
- *             the density in [1/cm^3]
- * Output: - Nothing
- ***************************************************************************/
+ *
+ * @param composition : Vector of tuples containing the mass number (first entry) and
+ *                      the density in [1/cm^3]
+ */
 void Radiation::SetAmbientMediumComposition(vector<vector< double > > composition){
     AmbientMediumComposition = composition;
     return;
@@ -1686,7 +1696,8 @@ void Radiation::SetAmbientMediumComposition(vector<vector< double > > compositio
  
 /**
  * Function to return the Hadron spectrum number i.
- * @param Number of the hadron component
+ *
+ * @param i : Number of the hadron component
  *
  * @return Spectrum, energy in [erg] and dN/dE in [1/(erg*cm^3)]
  */
@@ -1727,8 +1738,8 @@ vector<vector<double> > Radiation::GetAmbientMediumComposition(void){
 /**
  * Implementation of equation 20 in Kafexhiu et al. 2014
  * for one projectile species with mass number 'Mass'.
- * @param Energy [erg]
- * @param Mass number of the projectile
+ * @param Tp : Energy [erg]
+ * @param Mass : mass number of the projectile
  *
  * @return Epsilon factor
  */
@@ -1767,8 +1778,8 @@ double Radiation::CalculateEpsilon(double Tp, double Mass){
  * It is valid for projectile energies > 0.2 GeV for a proton projectile and > 0.1 GeV/nucleon for a nuclei
  * projectile different than a proton.
  *
- * @param Projectile mass number
- * @param Target mass number
+ * @param ProjMass : Projectile mass number
+ * @param TargetMass : Target mass number
  * 
  * @return Cross section in [mb]
  */
@@ -2146,11 +2157,16 @@ void Radiation::SetSSCTargetPhotons(double R, int steps, int i) {
 }
 
 /**
- * WRITE DOC
+ * Returns the sum of the target photon fields as vector of 2D tuples
+ * (log10(E/(1 erg)), log10((dN/dE)/(erg-1/cm-3)))
  *
- * @param bins
- * @param ISO
- * @return
+ * @param bins : bins for sampling the photon target field
+ * @param ISO : true to account only for the isotropic fields. false
+ *              to account for all the fields.
+ *
+ * @return vector of 2D tuple with the sum of the fields
+ *
+ * NOTE: this function could be private
  */
 vector< vector<double> > Radiation::SumTargetFields(int bins, bool ISO) {
     vector< vector<double> > vec;
@@ -2328,13 +2344,21 @@ void Radiation::CheckSanityOfTargetPhotonLookup() {
 //}
 
 /**
- * WRITE DOC
+ * Set anisotropy for photon field \a i. The anisotropy is passed can be passed
+ * as a python mesh grid. This function assumes that the electrons have a certain angle
+ * with respect to the observer.
  *
- * @param i
- * @param obs_angle
- * @param phi
- * @param theta
- * @param mesh
+ * See http://libgamera.github.io/GAMERA/docs/inverse_compton.html for a schematic
+ * view of the geometry
+ *
+ * @param i : index of the target field
+ * @param obs_angle : angle between the electron beam and x axis (observer)
+ *                    as a vector of coordinate (phi, theta)
+ * @param phi : vector of the phi coordinate of the anisotropy mesh grid of
+ *              the target photon field
+ * @param theta : vector of the theta coordinates of the anisotropy mesh grid
+ *                of the target photon field
+ * @param mesh : mesh grid of the anisotropy distribution of the target field
  */
 void Radiation::SetTargetPhotonAnisotropy(int i, vector<double> obs_angle, 
                                           vector<double> phi, vector<double> theta, 
@@ -2398,7 +2422,22 @@ void Radiation::SetTargetPhotonAnisotropy(int i, vector<double> obs_angle,
     return;
 }
 
-
+/**
+ * Set anisotropy for photon field \a i. The anisotropy is passed can be passed
+ * as a python mesh grid. This function assumes that the electrons have a
+ * isotropic distribution. This function sets Radiation::ISOTROPIC_ELECTRONS
+ * to true. This setting is not reversible. Do not mix isotropic and anisotropic
+ * distribuition of electrons.
+ *
+ * See http://libgamera.github.io/GAMERA/docs/inverse_compton.html for details.
+ *
+ * @param i : index of the target field
+ * @param phi : vector of the phi coordinate of the anisotropy mesh grid of
+ *              the target photon field
+ * @param theta : vector of the theta coordinates of the anisotropy mesh grid
+ *                of the target photon field
+ * @param mesh : mesh grid of the anisotropy distribution of the target field
+ */
 void Radiation::SetTargetPhotonAnisotropy(int i, 
                                           vector<double> phi, vector<double> theta, 
                                           vector< vector<double> > mesh) {
@@ -2461,19 +2500,25 @@ void Radiation::SetTargetPhotonAnisotropy(int i,
 }
 
 
-/* Function to set an isotropic electron distribution for the case of   *
- * anisotropic inverse Compton scattering                               */
+/**
+ *  Function to set an isotropic electron distribution for the case of
+ *  anisotropic inverse Compton scattering
+ */
 void Radiation::SetElectronsIsotropic(void){
     ISOTROPIC_ELECTRONS = true;
 }
 
 /**
- * WRITE DOC
+ * Returns the anisotropy map for the target photon \a i in the phormat of a
+ * mash grid, given the vectors of angular coordinates phi and theta.
  *
- * @param i
- * @param phi
- * @param theta
- * @return
+ * See http://libgamera.github.io/GAMERA/docs/inverse_compton.html for details.
+ *
+ * @param i : index of target field
+ * @param phi : vector phi coordinates
+ * @param theta : vector phi coordinates
+ *
+ * @return mesh grid style 2D array given the arrays of phi and theta
  */
 vector< vector<double> > Radiation::GetTargetPhotonAnisotropy(int i, 
                                      vector<double> phi, vector<double> theta) { 
@@ -2553,7 +2598,8 @@ void Radiation::CalculateDifferentialPhotonSpectrum(int steps, double emin,
 
 }
 
-/** Calculate differential photon spectra for the different radiation processes.
+/**
+ * Calculate differential photon spectra for the different radiation processes.
  *  Spectral points will be calculated for energy points given in 'points'.
  *  These points have to be in units of 'erg'!
  *  They are stored in the 2D 'diffspec' vector and can be accessed via the
@@ -2697,13 +2743,16 @@ void Radiation::CalculateDifferentialPhotonSpectrum(vector<double> points) {
 /**
  * Return the differential photon spectra dN/dE [number of photons/(erg*s*cm^2)]
  * vs E [erg] in a 2D-Vector
- * between the energies #emin and #emax. The argument #i determines the spectral
+ * between the energies \a emin and \a emax. The argument \a i determines the spectral
  * component to return:
  * - i = 1 : total spectrum
  * - i = 2 : pi0 decay
  * - i = 3 : IC scattering
  * - i = 4 : Bremsstrahlung
  * - i = 5 : Synchrotron radiation
+ * - i - 6 : hadronic spectrum
+ *
+ * TODO: might need to be private. Needs the spectral lookup as argument
  */
 vector<vector<double> > Radiation::ReturnDifferentialPhotonSpectrum(
               int i, double emin, double emax ,vector< vector<double> > vec) {
@@ -2727,12 +2776,16 @@ vector<vector<double> > Radiation::ReturnDifferentialPhotonSpectrum(
   return tempVec;
 }
 
-/** Return the photon SED (EdN/dE (erg/s/cm^2) vs E (TeV) in a 2D-Vector of
+/**
+ * Return the photon SED (EdN/dE (erg/s/cm^2) vs E (TeV) in a 2D-Vector of
  *  i = 1 : total spectrum
  *  i = 2 : pi0 decay
  *  i = 3 : IC scattering
  *  i = 4 : Bremsstrahlung
  *  i = 5 : Synchrotron radiation
+ *  i = 6 : hadronic spectrum
+ *
+ *  TODO: might need to be private. Needs the spectral lookup as argument
  */
 vector<vector<double> > Radiation::ReturnSED(int i, double emin, double emax, 
                                                 vector< vector<double> > vec) {
@@ -2756,6 +2809,17 @@ vector<vector<double> > Radiation::ReturnSED(int i, double emin, double emax,
   return tempVec;
 }
 
+/**
+ * Returns the Inverse Compton spectrum for target field \a i
+ * as vector of 2D tuples (E, dN/dE) in units of erg vs (1/cm2/s/erg)
+ *
+ * @param i : index of the target field for which to return the IC component
+ * @param emin : minimum energy in erg
+ * @param emax : maximum energy in erg
+ * @return Inverse compton differential spectrum
+ *
+ * Wrapped around Radiation::ReturnDifferentialPhotonSpectrum
+ */
 vector<vector<double> > Radiation::GetICSpectrum(unsigned int i, double emin, double emax) {
 
     if(IC_CALCULATED && FASTMODE_IC==true && epoints_temp.size()) {
@@ -2764,9 +2828,19 @@ vector<vector<double> > Radiation::GetICSpectrum(unsigned int i, double emin, do
         FASTMODE_IC=true;
     }
     return ReturnDifferentialPhotonSpectrum(i+1, emin, emax, diffSpecICComponents);
-}  ///< return Inverse Compton spectrum
+}
 
-
+/**
+ * Returns the Inverse Compton SED for target field \a i
+ * as vector of 2D tuples (E, E^2dN/dE) in units of TeV vs (erg/cm2/s)
+ *
+ * @param i : index of the target field for which to return the IC component
+ * @param emin : minimum energy in TeV
+ * @param emax : maximum energy in erg
+ * @return Inverse compton SED
+ *
+ * Wrapped around Radiation::ReturnSED
+ */
 vector<vector<double> > Radiation::GetICSED(unsigned int i, double emin, double emax) {
     if(IC_CALCULATED && FASTMODE_IC==true && epoints_temp.size()) {
         FASTMODE_IC=false;
@@ -2774,28 +2848,48 @@ vector<vector<double> > Radiation::GetICSED(unsigned int i, double emin, double 
         FASTMODE_IC=true;
     }
     return ReturnSED(i+1, emin, emax, diffSpecICComponents);
-  }  ///< return pi0 decay spectrum
+  }
 
-  
+/**
+ * Return pi0 decay spectrum from Hadron component \a i
+ *
+ * @param i : index of hadronic component
+ * @param emin : minimum energy in erg
+ * @param emax : maximum energy in erg
+ *
+ * @return Differential spectrum as vector of tuple E,dN/dE (erg, 1/erg/cm2/s)
+ *
+ * Wrapped around Radiation::ReturnDifferentialPhotonSpectrum
+ */
 vector<vector<double> > Radiation::GetHadronSpectrum(unsigned int i, double emin, double emax) {
     return ReturnDifferentialPhotonSpectrum(i+1, emin, emax, diffSpecHadronComponents);
-}  ///< return pi0 decay spectrum from Hadron component i
+}
 
-
+/**
+ * Return pi0 decay SED from Hadron component \a i
+ *
+ * @param i : index of hadronic component
+ * @param emin : minimum energy in TeV
+ * @param emax : maximum energy in TeV
+ *
+ * @return Differential spectrum as vector of tuple E,E^2dN/dE (TeV, 1/erg/cm2/s)
+ *
+ * Wrapped around Radiation::ReturnSED
+ */
 vector<vector<double> > Radiation::GetHadronSED(unsigned int i, double emin, double emax) {
     return ReturnSED(i+1, emin, emax, diffSpecHadronComponents);
-  }  ///< return pi0 decay spectrum from Hadron component i
-  
+  }
   
   
 /**
- * \brief Return a particle SED dN/dE vs E (erg vs TeV)
+ * \brief Return a particle SED E^2dN/dE vs E (erg vs TeV)
  * 
  * The particle vector is the one given by
  * Radiation::ElectronVector or Radiation::ProtonVector
  * 
- * Argument:
- * \arg \a type = "electron" or "proton"
+ * @param type = "electron" or "proton"
+ *
+ * @return vector of 2D tuple (E, E^2dN/dE) ([TeV], [erg])
  */
 vector<vector<double> > Radiation::GetParticleSED(string type) {
   vector<vector<double> > v;
@@ -3007,8 +3101,8 @@ void Radiation::ClearPhotonFieldSize(){
  *  * distance from source along the line of sight (in parsecs)
  *  * fractional value of the intensity value given when setting the photon field
  *
- *  @param int i = index of the target photon index
- *  @param vector < vector<double> > SpDp = Vector of the spatial dependency
+ *  @param i = index of the target photon index
+ *  @param SpDp = Vector of the spatial dependency
  *
  *  The function sets the boolean variable of the spatial dependency to true
  *  So to properly compute the integral of the absorption coefficient along
@@ -3221,7 +3315,7 @@ double Radiation::ComputeOptDepthIsotropic(double Egamma, int target, double phs
  * 
  * @param emin : minimum energy [erg]
  * @param emax : maximum energy [erg]
- * @param k : vector photon field counter to be used in the order the fields were added
+ * @param fields : vector photon field counter to be used in the order the fields were added
  * @param size : size of the photon field integration [cm]
  *
  * @return Absorbed Spectrum : vector of 2D tuple (E, dN/dE) ([erg],[1/erg-1/cm2/s])
@@ -3266,7 +3360,7 @@ vector< vector<double> > Radiation::ReturnAbsorbedSpectrumOnFields(double emin, 
  * 
  * @param emin : minimum energy [erg]
  * @param emax : maximum energy [erg]
- * @param k : vector photon field counter to be used in the order the fields were added
+ * @param fields : vector photon field counter to be used in the order the fields were added
  * @param size : size of the photon field integration [cm]
  *
  * @return Absorbed SED : vector of 2D tuple (E, dN/dE) ([erg],[erg/cm2/s])

--- a/src/Radiation.C
+++ b/src/Radiation.C
@@ -1271,8 +1271,9 @@ double Radiation::PPEmissivity(double x, void *par) {
   return c_speed * N * pow(10., logprotons) * ln10 * EP;
 }
 
-/** differential cross section following Kafexhiu 2014
- *  (Eq. 8)
+/**
+ * differential cross section following Kafexhiu 2014
+ * (Eq. 8)
  */
 double Radiation::DiffPPXSection(double Tp, double Eg) {
   double NuclearEnhancement = CalculateEpsilon(Tp, current_mass_number);
@@ -1582,13 +1583,14 @@ void Radiation::SetProtons(vector<vector<double> > PROTONS) {
 
 
 
-/*******************************************************************************
+/**
  * Function to add a spectrum of hadrons with a specific mass number. It also
  * calculates and saves a lookup for the spectrum.
- * Input:  - Spectrum of the hadrons
- *         - Mass number of the hadrons (number of the nucleons)
- * Output: Nothing
- *******************************************************************************/
+ *
+ * @param Spectrum of the hadrons (as vector of 2D-tuples (E,dN/dE) ([erg],[erg^-1]))
+ * @param Mass number of the hadrons (number of the nucleons)
+ *
+ */
 void Radiation::AddHadrons(vector<vector<double> > Spectrum, double Mass_number){
   HadronMasses.push_back(Mass_number);
   // The energy used in the equations is the energy per nucleon. Therefore we divide with the Mass_number
@@ -1682,11 +1684,12 @@ void Radiation::SetAmbientMediumComposition(vector<vector< double > > compositio
 }
  
  
-/********************************************************************
+/**
  * Function to return the Hadron spectrum number i.
- * Input:  - Number of the hadron component
- * Output: - Spectrum, energy in [erg] and dN/dE in [1/(erg*cm^3)]
- *******************************************************************/
+ * @param Number of the hadron component
+ *
+ * @return Spectrum, energy in [erg] and dN/dE in [1/(erg*cm^3)]
+ */
 vector<vector< double > > Radiation::GetHadrons(int i){ 
   vector<vector<double> > tempvec;
   if (i  >= (int)HadronSpectra.size()){
@@ -1701,33 +1704,34 @@ vector<vector< double > > Radiation::GetHadrons(int i){
   return tempvec;
 }
 
-/*****************************************************************
+/**
  * Function to return the mass numbers of the nuclei.
- * Input:   - Nothing
- * Output:  - Vector with the hadron masses
- ****************************************************************/
+ *
+ * @return Vector with the hadron masses in atomic units
+ */
 vector< double > Radiation::GetHadronMasses(void){
     return HadronMasses;
 }
 
-/**********************************************************************
+/**
  * Function to get back the composition and abundances of the ambient
  * medium.
- * Input:   - Nothing
- * Output:  - Vector of tuples containing the mass number (first entry)
- *              and the corresponding density
- *********************************************************************/
+ *
+ * @return Vector of tuples containing the mass number (first entry)
+ *         and the corresponding density in cm^-3
+ */
 vector<vector<double> > Radiation::GetAmbientMediumComposition(void){
     return AmbientMediumComposition;
 }
 
-/***********************************************************
+/**
  * Implementation of equation 20 in Kafexhiu et al. 2014
  * for one projectile species with mass number 'Mass'.
- * Input:   - Energy [erg]
- *          - Mass number of the projectile
- * Output:  - Epsilon factor
- **********************************************************/
+ * @param Energy [erg]
+ * @param Mass number of the projectile
+ *
+ * @return Epsilon factor
+ */
 double Radiation::CalculateEpsilon(double Tp, double Mass){
     double epsilon = 0.;
     double density = 0.;
@@ -1758,15 +1762,16 @@ double Radiation::CalculateEpsilon(double Tp, double Mass){
     return epsilon;
 }
 
-/*
- * This function calculates the nucleus-nucleus reaction cross section (equation 17 in Kafexhiu et al. 2014)
+/**
+ * Calculates the nucleus-nucleus reaction cross section (equation 17 in Kafexhiu et al. 2014)
  * It is valid for projectile energies > 0.2 GeV for a proton projectile and > 0.1 GeV/nucleon for a nuclei
  * projectile different than a proton.
- * Input parameters:    - Projectile mass number
- *                      - Target mass number
+ *
+ * @param Projectile mass number
+ * @param Target mass number
  * 
- * Output:              - Cross section in [mb]
- * */
+ * @return Cross section in [mb]
+ */
 double Radiation::NuNuXSection(double ProjMass, double TargetMass){
   double sigma_r0 = 58.1*1.0e-27; //mb to cm
   double beta0 = 2.247 - 0.915*(1.0+pow(TargetMass,-1.0/3.)); //projectile is a proton
@@ -1775,11 +1780,13 @@ double Radiation::NuNuXSection(double ProjMass, double TargetMass){
   return sigma_r;
 }
 
-/*
+/**
  * Function to return the average atomic number corresponding to
  * a certain mass number.
  * This is the semi-empirical formula (least square coefficients)
  * The relation is an approximation!
+ *
+ * @param mass_number : mass number of the atomic species
  */
 double Radiation::AtomicNumber(double mass_number){
 	if (mass_number < 3) {return 1;}
@@ -2138,6 +2145,13 @@ void Radiation::SetSSCTargetPhotons(double R, int steps, int i) {
   return;
 }
 
+/**
+ * WRITE DOC
+ *
+ * @param bins
+ * @param ISO
+ * @return
+ */
 vector< vector<double> > Radiation::SumTargetFields(int bins, bool ISO) {
     vector< vector<double> > vec;
     double eph_min = 100;
@@ -2303,7 +2317,7 @@ void Radiation::CheckSanityOfTargetPhotonLookup() {
   return;
 }
 
-/** remove the latest component in
+/* remove the latest component in
  * TotalTargetPhotonVector and recompute
  * the total target photon spectrum
  */
@@ -2313,7 +2327,15 @@ void Radiation::CheckSanityOfTargetPhotonLookup() {
 //  return;
 //}
 
-
+/**
+ * WRITE DOC
+ *
+ * @param i
+ * @param obs_angle
+ * @param phi
+ * @param theta
+ * @param mesh
+ */
 void Radiation::SetTargetPhotonAnisotropy(int i, vector<double> obs_angle, 
                                           vector<double> phi, vector<double> theta, 
                                           vector< vector<double> > mesh) {
@@ -2445,7 +2467,14 @@ void Radiation::SetElectronsIsotropic(void){
     ISOTROPIC_ELECTRONS = true;
 }
 
-
+/**
+ * WRITE DOC
+ *
+ * @param i
+ * @param phi
+ * @param theta
+ * @return
+ */
 vector< vector<double> > Radiation::GetTargetPhotonAnisotropy(int i, 
                                      vector<double> phi, vector<double> theta) { 
 
@@ -2878,6 +2907,7 @@ double Radiation::Integrate(fPointer f, double *x, double emin, double emax,
   else return integral;
 }
 
+
 vector<vector<double> > Radiation::GetTargetPhotons(int i) {
 	// Now throws error when the field has not been specified
 	// Otherwise crash without explanation given
@@ -2944,8 +2974,9 @@ vector <double> Radiation::GetSizePhotonField(){
 /**
  * Return size photon field only for the i-th field.
  *
- * Arguments:
- *   - i = target photon fiels
+ * @param i : target photon fiels
+ *
+ * @return size of the photon field \a i [cm]
  */
 double Radiation::GetSizePhotonField(int i){
 	if (sizephfield[i]==0.){
@@ -2975,12 +3006,14 @@ void Radiation::ClearPhotonFieldSize(){
  * The user provides a vector of tuples composed of 2 elements:
  *  * distance from source along the line of sight (in parsecs)
  *  * fractional value of the intensity value given when setting the photon field
- *  Arguments:
- *      - int i = index of the target photon index
- *      - vector < vector<double> > SpDp = Vector of the spatial dependency
+ *
+ *  @param int i = index of the target photon index
+ *  @param vector < vector<double> > SpDp = Vector of the spatial dependency
+ *
  *  The function sets the boolean variable of the spatial dependency to true
  *  So to properly compute the integral of the absorption coefficient along
  *  the line of sight.
+ *
  *  The function converts the spatial quantity given in parsec to a quantity in cm
  */
 void Radiation::SetTargetFieldSpatialDep(int i,vector< vector<double> > SpDp){
@@ -2998,15 +3031,14 @@ void Radiation::SetTargetFieldSpatialDep(int i,vector< vector<double> > SpDp){
 
 
 /**
- *  Return the spatial dependence of the target field i
+ *  Return the spatial dependence of the target field \a i
  *  The return gives the spatial size in cm
  *  If the target does not exist or has no spatial dependency
  *  returns an empty vector
  *
- *  Arguments:
- *     - i = target photon field
- *  Returns:
- *     - Spatial dependency array ( r,normalization(r) ) distance in units of cm
+ *  @param i = target photon field
+ *
+ *  @return Spatial dependency array ( r,normalization(r) ) distance in units of cm
 */
 vector< vector<double> > Radiation::GetTargetFieldSPatialDep(int i){
 	if (SpatialDep[i].size()){
@@ -3022,11 +3054,10 @@ vector< vector<double> > Radiation::GetTargetFieldSPatialDep(int i){
  * Eq. 5 from (Eungwanichayapant & Aharonian, 2009) https://arxiv.org/pdf/0907.2971.pdf
  * This is approximated and good within 3%
  * 
- * Arguments:
- *     - Eph1 = energy of the first photon (in ergs)
- *     - Eph2 = energy of the second photon (in ergs)
- * Returns:
- *     - the averaged gamma-gamma cross section
+ * @param Eph1 = energy of the first photon (in ergs)
+ * @param Eph2 = energy of the second photon (in ergs)
+ *
+ * @return the averaged gamma-gamma cross section [cm^2]
  * 
  */
 double Radiation::AverageSigmaGammaGamma(double Eph1, double Eph2) {
@@ -3044,12 +3075,11 @@ double Radiation::AverageSigmaGammaGamma(double Eph1, double Eph2) {
  * Function for the full gamma gamma absorption cross section
  * Eq. 1 from Vernetto&Lipari 2016 (https://arxiv.org/pdf/1608.01587v2.pdf)
  * 
- * Arguments:
- *     - Eph1 = energy of the first photon (in ergs)
- *     - Eph2 = energy of the second photon (in ergs)
- *     - costheta= cosine of scattering angle  (in radiands)
- * Returns:
- *     - the gamma-gamma cross section
+ * @param Eph1 : energy of the first photon (in ergs)
+ * @param Eph2 : energy of the second photon (in ergs)
+ * @param costheta : cosine of scattering angle  (in radiands)
+ *
+ * @return gamma-gamma cross section [cm^2]
  */
 double Radiation::SigmaGammaGamma(double Eph1,double Eph2, double costheta) {
 	double CMene = 2.*Eph1*Eph2*(1-costheta)/(4.*m_e*m_e);  // Centre Mass energy
@@ -3070,11 +3100,11 @@ double Radiation::SigmaGammaGamma(double Eph1,double Eph2, double costheta) {
  * The function takes into account the angular anisotropy of the photon field
  * through interpolation of the mesh grid of the angular dependencies.
  * Angular integration is a simple rectangular integration.
- * Arguments:
- *      - double Egamma = energy of the gamma-ray photon (in erg)
- *      - int target = target photon field to compute the absorption
- * Returns:
- *      - Absorption coefficient. Units of 1/cm
+ *
+ * @param Egamma : energy of the gamma-ray photon (in erg)
+ * @param target : target photon field to compute the absorption
+ *
+ * @return Absorption coefficient. Units of 1/cm
  */
 double Radiation::ComputeAbsCoeff(double Egamma, int target) {
 	vector< vector<double> > targets = Radiation::GetTargetPhotons(target);
@@ -3126,6 +3156,14 @@ double Radiation::ComputeAbsCoeff(double Egamma, int target) {
  * Functions for the calculation of the optical depth
  * Takes as argument just the energy f the gamma ray photon and computes the optical
  * depth for the chosen target photon
+ *
+ * @param Egamma : energy of the gamma ray [erg]
+ * @param target : index of the photon field target
+ * @param phsize : patial size of the photon field [cm]
+ *
+ * For the non-homogeneous field case, it assumes that Radiation::SpatialDep
+ * has been initialized via Radiation::SetTargetFieldSpatialDep
+ *
  * !!! CAREFUL UNDER CONSTRUCTION !!!
  * !!! Implemented simple spatial variability of the target photons
  * !!! The SpatialDep array is a scaling relation.
@@ -3155,6 +3193,10 @@ double Radiation::ComputeOptDepth(double Egamma, int target, double phsize){
  * Takes as argument just the energy f the gamma ray photon and computes the optical
  * depth for the sum of the target photons that are present
  * At the moment it works only for isotropic and homogeneous case
+ *
+ * @param Egamma : energy of the gamma ray [erg]
+ * @param target : index of the photon field target
+ * @param phsize : spatial size of the photon field [cm]
  */
 double Radiation::ComputeOptDepthIsotropic(double Egamma, int target, double phsize){
     double tauval=0;
@@ -3174,16 +3216,15 @@ double Radiation::ComputeOptDepthIsotropic(double Egamma, int target, double phs
 
 /**
  * Return the total absorbed differential spectrum (for the moment using the homogeneous and isotropic case)
- * This is a wrapper around the function ReturnSED to which it was added the distance
+ * This is a wrapper around the function ReturnDifferentialPhotonSpectrum to which it was added the distance
  * parameter needed to compute the right absorption and the target photon field for the absorption
  * 
- * Parameters:
- *  - double emin = minimum energy
- *  - double emax = maximum energy
- *  - int k = vector photon field counter to be used in the order the fields were added
- *  - size = size of the photon field integration
- * Returns:
- *  - Absorbed Spectrum
+ * @param emin : minimum energy [erg]
+ * @param emax : maximum energy [erg]
+ * @param k : vector photon field counter to be used in the order the fields were added
+ * @param size : size of the photon field integration [cm]
+ *
+ * @return Absorbed Spectrum : vector of 2D tuple (E, dN/dE) ([erg],[1/erg-1/cm2/s])
  */
 vector< vector<double> > Radiation::ReturnAbsorbedSpectrumOnFields(double emin, double emax, vector <int> fields, vector <double> size) {
     double tauval=0;
@@ -3223,14 +3264,12 @@ vector< vector<double> > Radiation::ReturnAbsorbedSpectrumOnFields(double emin, 
  * This is a wrapper around the function ReturnSED to which it was added the distance
  * parameter needed to compute the right absoption and the target photon field for the absorption
  * 
- * Parameters:
- *  - double emin = minimum energy
- *  - double emax = maximum energy
- *  - int k = vector photon field counter to be used in the order the fields were added
- *  - size = size of the photon field integration
+ * @param emin : minimum energy [erg]
+ * @param emax : maximum energy [erg]
+ * @param k : vector photon field counter to be used in the order the fields were added
+ * @param size : size of the photon field integration [cm]
  *
- * Returns:
- *  - Absorbed SED
+ * @return Absorbed SED : vector of 2D tuple (E, dN/dE) ([erg],[erg/cm2/s])
  */
 vector< vector<double> > Radiation::ReturnAbsorbedSEDonFields(double emin, double emax,
                                                         vector <int> fields, vector <double> size){
@@ -3268,6 +3307,14 @@ vector< vector<double> > Radiation::ReturnAbsorbedSEDonFields(double emin, doubl
 /**
  * Returns the absorbed integrated flux. The absorption is computed using all the photon fields that enter in the
  * absorption calculation
+ *
+ * @param emin : minimum energy for the integration [erg]
+ * @param emax : maximum energy for the integration [erg]
+ * @param ENERGYFLUX : if true intgrates Edn/dE if false dn/dE
+ * @param fields : vector of indices of fields used to compute the absorption
+ * @param size : vector of sizes of the fields used to compute absorption (sizes in cm)
+ *
+ * @return val : integral flux (1/cm2/s) or integral energy flux (erg/cm2/s)
  */
 double Radiation::ReturnAbsorbedIntergratedFlux(double emin, double emax, bool ENERGYFLUX, vector <int> fields, vector <double > size){
     if (!diffSpec.size()){

--- a/src/Utils.C
+++ b/src/Utils.C
@@ -95,6 +95,12 @@ int Utils::ReadParameterFile(string inputname, vector<string> parameter_names,
   return 0;
 }
 
+/**
+ * Write spectrum \a sp on file
+ *
+ * @param sp : vector of 2D tuples to be written
+ * @param outname : file name (including extension)
+ */
 void Utils::WriteOut(vector<vector<double> > sp, string outname) {
 
   ofstream output_file(outname.c_str());
@@ -111,6 +117,12 @@ void Utils::WriteOut(vector<vector<double> > sp, string outname) {
   output_file.close();
 }
 
+/**
+ * Read spectrum \a sp from file
+ *
+ * @param inname : file name (including extension)
+ * @param sp : vector of 2D tuples where to store the input
+ */
 void Utils::ReadIn(string inname, vector< vector<double> > &sp) {
   sp.clear();
   ifstream input_file(inname.c_str());
@@ -243,8 +255,13 @@ double Utils::Random() {
 }
 
 /**
-* get n uniform random numbers in [x_min,x_max)
-*/
+ * Get n uniform random numbers in [x_min,x_max)
+ *
+ * @param x_min : minimum value
+ * @param x_max : maximum value
+ * @param n : number of element requested
+ * @return vector of random numbers uniformly distributed
+ */
 vector<double> Utils::UniformRandom(double x_min, double x_max,int n) {
   vector<double> v;
   for(int i=0;i<n;i++) v.push_back(x_min + (x_max-x_min)*gsl_rng_uniform(r));
@@ -252,8 +269,14 @@ vector<double> Utils::UniformRandom(double x_min, double x_max,int n) {
 }
 
 /**
-* get linearly distributed variates
-*/
+ * Get linearly distributed variates between [x_min, x_max) given a slope
+ *
+ * @param slope : angular coefficient of the line between x_min and x_max
+ * @param x_min : minimum value
+ * @param x_max : minimum value
+ * @param n : number of requested values
+ * @return vector of random numbers linearly distributed
+ */
 vector<double> Utils::LinearRandom(double slope, double x_min,
                                    double x_max, int n) {
   vector<double> v;
@@ -270,8 +293,16 @@ vector<double> Utils::LinearRandom(double slope, double x_min,
 }
 
 /**
-* get power-law distributed variates TODO: Index == 1
-*/
+ * get power-law distributed variates between [x_min, x_max) given a slope
+ *
+ * @param index : power law index
+ * @param x_min : minimum value
+ * @param x_max : minimum value
+ * @param n : number of requested values
+ * @return vector of random numbers distributed as a power law
+ *
+ * TODO: Index == 1 not included!!!
+ */
 vector<double> Utils::PowerLawRandom(double index, double x_min,
                                      double x_max, int n) {
   vector<double> v;
@@ -461,15 +492,17 @@ vector< vector<double> > Utils::CustomFunctionRandom2D(vector< vector<double> > 
 
 
 
-/***********************************************************************
+/**
  * Function to calculate the total energy of a spectrum between a
- * maximum nd a minimum energy.
- * Input:   - vector containing the energy and dN/dE as tuples.
- *              The energy and dN/dE should have the same energy unit.
- *          - Minimum energy
- *          - Maximum energy
- * Output:  - Energy in units of the input energy
- **********************************************************************/
+ * maximum and a minimum energy.
+ *
+ * @param f : vector containing the energy and dN/dE as tuples.
+ *            The energy and dN/dE should have the same energy unit.
+ * @param emin : Minimum energy
+ * @param emax : Maximum energy
+ *
+ * @return Energy in units of the input energy
+ */
 double Utils::EnergyContent(vector< vector<double> > f, double emin, double emax) {
   if(!f.size()) {
     cout << "Utils::EnergyContent: spectrum vector empty! "
@@ -488,7 +521,7 @@ double Utils::EnergyContentFast(vector< vector<double> > f) {
 }
 
 
-///**
+//
 // * get Poissonian variate (just wrapped from TRandom))
 // */
 // int Utils::PoissonianRandom(double mean) {
@@ -679,6 +712,10 @@ vector< vector<double> > Utils::VectorAxisLogarithm(vector< vector<double> > v,
   return v;
 }
 
+/**
+ * Transform the quantity in the \a column column of vector v in a base 10 exponential
+ * quantity
+ */
 vector< vector<double> > Utils::VectorAxisPow10(vector< vector<double> > v,
                                                     int column) {
   for(unsigned int i = 0; i < v.size() ; i++) {


### PR DESCRIPTION
 This update:
 - Fixes the ionization losses and makes them active only for protons. They are not active by default.
 - Fixes some inconsistencies in the calculation bremsstrahlung between classes concerning the ambient density (especially for radiation class)
 - Adds more documentation of the API in doxygen style.